### PR TITLE
Update README for Apptainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# Singularity User Docs
+# Apptainer User Docs
 
 This repository holds user-facing documentation for the
-[Singularity](https://github.com/hpcng/singularity) container runtime.
+[Apptainer](https://github.com/apptainer/apptainer) container runtime.
 
-This is a community project led by [HPCng](https:/hpcng.org), and
-contributions are always welcome! If you'd like to update or improve
-Singularity's documentation please follow the instructions below, and submit a
-PR on GitHub.
+This is a community project maintained as a sub-project by the
+[Apptainer](https:/apptainer.org) project,
+and contributions are always welcome! If you'd like to update or improve
+Apptainer's documentation please read the
+[Apptainer CONTRIBUTING file](https://github.com/apptainer/apptainer/CONTRIBUTING.md),
+follow the instructions below, and submit a PR on GitHub.
+
+
 
 ## Setting up an environment to contribute
 
-The Singularity user documentation is written in [reStructured Text (RST)
+The Apptainer user documentation is written in [reStructured Text (RST)
 format](http://docutils.sourceforge.net/rst.html) and generated using
 [Sphinx](https://pypi.org/project/Sphinx/). The
 [ReadTheDocs](https://readthedocs.org/) theme for Sphinx is used.
@@ -60,13 +64,13 @@ This file sets the themes, extensions, variables and naming scheme for output
 created when building the documentation with Sphinx. Some important elements
 include:
 
-- `version` : Describes the current version of `Singularity` that the
-  documentation is for. We set version to the `major.minor` values, e.g. `3.5`,
+- `version` : Describes the current version of `Apptainer` that the
+  documentation is for. We set version to the `major.minor` values, e.g. `1.0`,
   as we are not creating separate documentation for each patch release.
 - `release`: Would be used to specify the current release of the software being
   documented, including patch number, alpha tags etc. We leave this the same as
   `version` as we only generate documentation for each `major.minor` version of
-  singularity.
+  apptainer.
 - `html_theme`: Sets the theme to be used for HTML output. We are using the RTD
   or Read The Docs theme.
 - `html_context`: Options here control links back to our GitHub repository.
@@ -168,7 +172,7 @@ These are some of the basics of RST. For a more complete introduction, see the
 ### Building HTML documentation
 
 To build the HTML documentation, make sure you are in the top level of the
-`singularity-userdocs` repository and run:
+`apptainer-userdocs` repository and run:
 
 ```sh
 make html SKIPCLI=1
@@ -178,7 +182,7 @@ This will generate a folder called `_build/html` with the output. Open
 `index.html` to browse the documentation.
 
 The `SKIPCLI=1` option tells `make` not to generate the CLI reference, which is
-created automatically from the Singularity source code. You can generate the CLI
+created automatically from the Apptainer source code. You can generate the CLI
 documentation by running `make html` alone. This requires a Go build
 environment (see below).
 
@@ -191,7 +195,7 @@ make latexpdf SKIPCLI=1
 ```
 
 Output is written into `_build/latex` and the final PDF will be named
-`singularity-userdocs.pdf`
+`apptainer-userdocs.pdf`
 
 ### Generating EPUB from RST
 
@@ -202,30 +206,31 @@ make epub SKIPCLI=1
 ```
 
 Output is written into `_build/epub` and the final EPUB will be named
-`singularity-userdocs.epub`
+`apptainer-userdocs.epub`
 
 ## Generating CLI docs
 
-The Singularity CLI docs are generated using the actual code from Singularity.
-To do this, we include Singularity as a git submodule, and whenever a Makefile
-target (like `make html`) is run, Singularity itself is compiled and used to
+The Apptainer CLI docs are generated using the actual code from
+Apptainer.
+To do this, we include Apptainer as a git submodule, and whenever a Makefile
+target (like `make html`) is run, Apptainer itself is compiled and used to
 generate the CLI docs.
 
-However, you might not want to compile Singularity, either because you can't on
+However, you might not want to compile Apptainer, either because you can't on
 your machine, or because you want to test out a quick change to the docs.  If
 this is the case, you can skip the CLI doc generation using the `SKIPCLI`
 argument.  For example, to rebuild the HTML docs without including the CLI docs,
 just run `make html SKIPCLI=1`.
 
-If Singularity has been updated and you want to synchronize the CLI docs with
-the new version of Singularity, you'll have to update the submodule.  To do
+If Apptainer has been updated and you want to synchronize the CLI docs with
+the new version of Apptainer, you'll have to update the submodule.  To do
 this, just run:
 
 ```bash
 git submodule update --remote --merge
-git add vendor/src/github.com/hpcng/singularity
+git add vendor/src/github.com/apptainer/apptainer
 git commit
 ```
 
-This will update the Singularity submodule to the latest version of the master
+This will update the Apptainer submodule to the latest version of the master
 branch.


### PR DESCRIPTION
Rename everything in README from Singularity to Apptainer. Changes in the documentation will come later.