### PR TITLE
Remove references to older singularity versions

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -13,7 +13,7 @@
  {Singularity}'s environment variables
 ***************************************
 
-{Singularity} 3.0 comes with some environment variables you can set or
+{Singularity} comes with some environment variables you can set or
 modify depending on your needs. You can see them listed alphabetically
 below with their respective functionality.
 

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -41,7 +41,7 @@ container.
 Disabling System Binds
 ======================
 
-The ``--no-mount`` flag, added in {Singularity} 3.7, allows specific
+The ``--no-mount`` flag allows specific
 system mounts to be disabled, even if they are set in the
 ``singularity.conf`` configuration file by the administrator.
 
@@ -83,7 +83,7 @@ specified as ``ro`` (read-only) or ``rw`` (read/write, which is the
 default). The ``--bind/-B`` option can be specified multiple times, or a
 comma-delimited string of bind path specifications can be used.
 
-{Singularity} 3.9 adds an additional ``--mount`` flag, which provides a
+{Singularity} also has a ``--mount`` flag, which provides a
 longer-form method of specifying binds in ``--mount
 type=bind,src=<source>,dst=<destination>[,<option>]...`` format. This is
 compatible with the ``--mount`` syntax for binds in Docker and other OCI
@@ -201,7 +201,7 @@ defined within the container. The bind point is a directory within the
 container that {Singularity} can use as a destination to bind a
 directory on the host system.
 
-Starting in version 3.0, {Singularity} will do its best to bind mount
+{Singularity} will do its best to bind mount
 requested paths into a container regardless of whether the appropriate
 bind point exists within the container. {Singularity} can often carry
 out this operation even in the absence of the "overlay fs" feature.
@@ -264,8 +264,8 @@ mount a remote computer's filesystem to your local host, over ssh:
    # Now mounted to my local machine:
    $ ythel:/home/dave on /home/dave/other_host type fuse.sshfs (rw,nosuid,nodev,relatime,user_id=1000,group_id=1000)
 
-{Singularity} 3.6 introduces the ``--fusemount`` option, which allows
-you directly expose FUSE filesystems inside a container. The FUSE
+{Singularity} has a ``--fusemount`` option, which allows
+you to directly expose FUSE filesystems inside a container. The FUSE
 command / driver that mounts a particular type of filesystem can be
 located on the host, or in the container.
 
@@ -274,12 +274,6 @@ The FUSE command *must* be based on libfuse3 to work correctly with
 that provides FUSE commands such as ``sshfs`` based on FUSE 2 then you
 can install FUSE 3 versions of the commands you need inside your
 container.
-
-.. note::
-
-   ``--fusemount`` functionality was present in a hidden preview state
-   from {Singularity} 3.4. The behavior has changed for the final
-   supported version introduced in {Singularity} 3.6.
 
 FUSE mount definitions
 ======================
@@ -348,7 +342,7 @@ added to your container, you can use the ``container`` mount type:
  Image Mounts
 **************
 
-In {Singularity} 3.6 and above you can mount a directory contained in an
+In {Singularity} you can mount a directory contained in an
 image file into a container. This may be useful if you want to
 distribute directories containing a large number of data files as a
 single image file.

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -167,7 +167,7 @@ machine requires root privileges.
  Building encrypted containers
 *******************************
 
-Beginning in {Singularity} 3.4.0 it is possible to build and run
+With {Singularity} it is possible to build and run
 encrypted containers. The containers are decrypted at runtime entirely
 in kernel space, meaning that no intermediate decrypted data is ever
 present on disk or in memory. See :ref:`encrypted containers
@@ -180,7 +180,7 @@ present on disk or in memory. See :ref:`encrypted containers
 ``--builder``
 =============
 
-{Singularity} 3.0 introduces the option to perform a remote build. The
+{Singularity} gives the option to perform a remote build. The
 ``--builder`` option allows you to specify a URL to a different build
 service. For instance, you may need to specify a URL to build to an on
 premises installation of the remote builder. This option must be used in
@@ -255,7 +255,7 @@ container file system at build time. See :ref:`encrypted containers
 ``--remote``
 ============
 
-{Singularity} 3.0 introduces the ability to build a container on an
+{Singularity} includes the ability to build a container on an
 external resource running a remote builder. (The default remote builder
 is located at "https://cloud.sylabs.io/builder".)
 
@@ -317,7 +317,7 @@ your build environment. Libraries are mounted during the execution of
 .. note::
 
     This option can't be set via the environment variable `SINGULARITY_ROCM`.
-    Singularity will attempt to bind binaries listed in SINGULARITY_CONFDIR/rocmliblist.conf,
+    Singularity will attempt to bind binaries listed in `SINGULARITY_CONFDIR/rocmliblist.conf`,
     if the mount destination doesn't exist inside the container, they are ignored.
 
 ``--bind``

--- a/build_env.rst
+++ b/build_env.rst
@@ -254,7 +254,7 @@ Remember to use ``-E`` option to pass the value of
  Encrypted Containers
 **********************
 
-Beginning in {Singularity} 3.4.0 it is possible to build and run
+With {Singularity} it is possible to build and run
 encrypted containers. The containers are decrypted at runtime entirely
 in kernel space, meaning that no intermediate decrypted data is ever
 present on disk or in memory. See :ref:`encrypted containers

--- a/cgroups.rst
+++ b/cgroups.rst
@@ -75,7 +75,7 @@ https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
  Using Singularity to Create a Cgroup
 **************************************
 
-{Singularity} 3.9 and above can directly apply resource limitations to
+{Singularity} allows you to directly apply resource limitations to
 systems configured for both cgroups v1 and the v2 unified hierarchy.
 Resource limits are specified using a TOML file that represents the
 `resources` section of the OCI runtime-spec:

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -55,7 +55,7 @@ Library <https://cloud.sylabs.io/library>`_ as a base. Similarly, the
 ``docker`` bootstrap agent will pull docker layers from `Docker Hub
 <https://hub.docker.com/>`_ as a base OS to start your image.
 
-Starting with {Singularity} 3.2, the ``Bootstrap`` keyword needs to be
+The ``Bootstrap`` keyword needs to be
 the first entry in the header section. This breaks compatibility with
 older versions that allow the parameters of the header to appear in any
 order.
@@ -132,8 +132,7 @@ that has been modified after signing, will produce a warning but the
 build will continue.
 
 To enforce that the bootstrap image verifies correctly and has been
-signed by one or more keys, you can use the ``Fingerprints:`` header
-introduced in {Singularity} 3.7.
+signed by one or more keys, you can use the ``Fingerprints:`` header.
 
 .. code:: singularity
 
@@ -255,7 +254,7 @@ host**. We'll use ``file1`` to demonstrate the usage of the ``%files``
 section below. The ``file2`` is created at the root of the file system
 **within the container**.
 
-In later versions of {Singularity} the ``%files`` section is provided as
+The ``%files`` section is provided as
 a safer alternative to copying files from the host system into the
 container during the build. Because of the potential danger involved in
 running the ``%setup`` scriptlet with elevated privileges on the host
@@ -633,7 +632,7 @@ After building the help can be displayed like so:
  Multi-Stage Builds
 ********************
 
-Starting with {Singularity} v3.2 multi-stage builds are supported where
+Multi-stage builds are supported where
 one environment can be used for compilation, then the resulting binary
 can be copied into a final environment. This allows a slimmer final
 image that does not require the entire development stack.

--- a/encryption.rst
+++ b/encryption.rst
@@ -11,8 +11,8 @@ encrypting the root file system.
  Overview
 **********
 
-In {Singularity} >= v3.4.0 a new feature to build and run encrypted
-containers has been added to allow users to encrypt the file system
+{Singularity} provides a feature to build and run encrypted
+containers to allow users to encrypt the file system
 image within a SIF. This encryption can be performed using either a
 passphrase or asymmetrically via an RSA key pair in Privacy Enhanced
 Mail (PEM/PKCS1) format. The container is encrypted in transit, at rest,
@@ -36,14 +36,6 @@ A container can be encrypted either by supplying a plaintext passphrase
 or a PEM file containing an asymmetric RSA public key. Of these two
 methods the PEM file is more secure and is therefore recommended for
 production use.
-
-.. note::
-
-   In {Singularity} 3.4, the definition file stored with the container
-   will not be encrypted. If it contains sensitive information you
-   should remove it before encryption via ``singularity sif del 1
-   myimage.sif``. Metadata encryption will be addressed in a future
-   release.
 
 An ``-e|--encrypt`` flag to ``singularity build`` is used to indicate
 that the container needs to be encrypted.

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -280,7 +280,7 @@ in the output of ``remote list``:
 
    * Active cloud services keyserver
 
-{Singularity} 3.7 introduces the ability for an administrator to make a
+An administrator can make a
 remote the only usable remote for the system by using the
 ``--exclusive`` flag:
 

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -22,35 +22,6 @@ details such as the version of {Singularity} used are present as
 :ref:`labels <sec:labels>` on a container. You can also specify your own
 to be recorded against your container.
 
-******************************
- Changes in {Singularity} 3.6
-******************************
-
-{Singularity} 3.6 modified the ways in which environment variables are
-handled to allow long-term stability and consistency that has been
-lacking in prior versions. It also introduced new ways of setting
-environment variables, such as the ``--env`` and ``--env-file`` options.
-
-.. warning::
-
-   If you have containers built with {Singularity} <3.6, and frequently
-   set and override environment variables, please review this section
-   carefully. Some behavior has changed.
-
-Summary of changes
-==================
-
-   -  When building a container, the environment defined in the base
-      image (e.g. a Docker image) is available during the ``%post``
-      section of the build.
-
-   -  An environment variable set in a container image, from the
-      bootstrap base image, or in the ``%environment`` section of a
-      definition file *will not* be overridden by a host environment
-      variable of the same name. The ``--env``, ``--env-file``, or
-      ``SINGULARITYENV_`` methods must be used to explicitly override a
-      environment variable set by the container image.
-
 **********************
  Environment Overview
 **********************
@@ -148,11 +119,10 @@ The ``%runscript`` is set to echo the value.
 
 .. warning::
 
-   {Singularity} 3.6 uses an embedded shell interpreter to evaluate and
+   {Singularity} uses an embedded shell interpreter to evaluate and
    setup container environments, therefore all commands executed from
-   the ``%environment`` section have an execution timeout of **5
-   seconds** for {Singularity} 3.6 and a **1 minute** timeout since
-   {Singularity} 3.7. While it is fine to source a script from there, it
+   the ``%environment`` section have an execution timeout of **1 minute**. 
+   While it is fine to source a script from there, it
    is not recommended to use this section to run potentially long
    initialization tasks because this would impact users running the
    image and the execution could abort due to timeout.
@@ -263,8 +233,6 @@ variables include special characters.
 ``--env-file`` option
 =====================
 
-*New in {Singularity} 3.6*
-
 The ``--env-file`` option lets you provide a file that contains
 environment variables as ``NAME=VALUE`` pairs, e.g.:
 
@@ -364,7 +332,7 @@ as ``--env APPEND_PATH="/endpath"``.
 Environment Variable Precedence
 ===============================
 
-When a container is run with {Singularity} 3.6, the container
+When a container is run with {Singularity}, the container
 environment is constructed in the following order:
 
    -  Clear the environment, keeping just ``HOME`` and
@@ -400,7 +368,7 @@ new files.
    A detailed description of what the ``umask`` is, and how it works can
    be found at `Wikipedia <https://en.wikipedia.org/wiki/Umask>`__.
 
-{Singularity} 3.7 and above set the ``umask`` in the container to match
+{Singularity} sets the ``umask`` in the container to match
 the value outside, unless:
 
    -  The ``--fakeroot`` option is used, in which case a ``0022`` umask
@@ -410,11 +378,6 @@ the value outside, unless:
 
    -  The ``--no-umask`` option is used, in which case a ``0022`` umask
       is set.
-
-.. note::
-
-   In {Singularity} 3.6 and below a default ``0022`` umask was always
-   applied.
 
 .. _sec:metadata:
 
@@ -427,9 +390,8 @@ it was built, etc. This metadata includes the definition file used to
 build the container and labels, which are specific pieces of information
 set automatically or explicitly when the container is built.
 
-For containers that are generated with {Singularity} version 3.0 and
-later, default labels are represented using the `rc1 Label Schema
-<http://label-schema.org/rc1/>`_.
+{Singularity} container default labels are represented using the
+`rc1 Label Schema <http://label-schema.org/rc1/>`_.
 
 .. _sec:labels:
 
@@ -480,7 +442,7 @@ when you are writing the definition file, but can be obtained in the
 ``%post`` section of your definition file while the container is
 building.
 
-{Singularity} 3.7 and above allow this, through adding labels to the
+{Singularity} allows this, through adding labels to the
 file defined by the ``SINGULARITY_LABELS`` environment variable in the
 ``%post`` section:
 
@@ -741,7 +703,7 @@ environment files that are used when a container is executed.
 
 *You should not manually modify* files under ``/.singularity.d``, from
 your definition file during builds, or directly within your container
-image. Recent 3.x versions of {Singularity} replace older action scripts
+image. {Singularity} replaces older action scripts
 dynamically, at runtime, to support new features. In the longer term,
 metadata will be moved outside of the container, and stored only in the
 SIF file metadata descriptor.
@@ -783,7 +745,7 @@ SIF file metadata descriptor.
    ``/.singularity.d/env/90-environment.sh``. Whenever possible, avoid
    modifying or creating environment files manually to prevent potential
    issues building & running containers with future versions of
-   {Singularity}. Beginning with {Singularity} 3.6, additional
+   {Singularity}. Additional
    facilities such as ``--env`` and ``--env-file`` are available to
    allow manipulation of the container environment at runtime.
 

--- a/fakeroot.rst
+++ b/fakeroot.rst
@@ -99,8 +99,8 @@ mappings in ``/etc/subgid``, so your username needs to be listed in
 those files with a valid mapping (see the admin-guide for details), if
 you can't edit the files ask an administrator.
 
-In {Singularity} ``3.5`` a ``singularity config fakeroot`` command has
-been added to allow configuration of the ``/etc/subuid`` and
+{Singularity} provides a ``singularity config fakeroot`` command 
+to allow configuration of the ``/etc/subuid`` and
 ``/etc/subgid`` mappings from the {Singularity} command line. You must
 be a root user or run with ``sudo`` to use ``config fakeroot``, as the
 mapping files are security sensitive. See the admin-guide for more

--- a/gpu.rst
+++ b/gpu.rst
@@ -15,7 +15,7 @@ older RHEL 7 host.
 Applications that support OpenCL for compute acceleration can also be
 used easily, with an additional bind option.
 
-With {Singularity} 3.9 experimental support has been introduced to use
+{Singularity} experimental support is provided to use
 Nvidia's ``nvidia-container-cli`` tooling for GPU container setup. This
 functionality, accessible via the new ``--nvccli`` flag, improves
 compatibility with OCI runtimes and exposes additional container
@@ -194,8 +194,8 @@ avoid driver unload.
  NVIDIA GPUs & CUDA (nvidia-container-cli)
 *******************************************
 
-{Singularity} 3.9 introduces the ``--nvccli`` option, which will
-instruct {Singularity} to perform GPU container setup using the
+The ``--nvccli`` option instructs
+{Singularity} to perform GPU container setup using the
 ``nvidia-container-cli`` utility. This utility must be installed
 separately from {Singularity}. It is available in the repositories of
 some distributions, and at:
@@ -203,7 +203,7 @@ https://nvidia.github.io/libnvidia-container/
 
 .. warning::
 
-   This feature is considered experimental in {Singularity} 3.9. It
+   This feature is considered experimental in {Singularity} as of now. It
    cannot not replace the legacy NVIDIA support in all situations, and
    should be tested carefully before use in production workflows.
 
@@ -392,7 +392,7 @@ https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.htm
  AMD GPUs & ROCm
 *****************
 
-{Singularity} 3.5 adds a ``--rocm`` flag to support GPU compute with the
+{Singularity} has a ``--rocm`` flag to support GPU compute with the
 ROCm framework using AMD Radeon GPU cards.
 
 Commands that ``run``, or otherwise execute containers (``shell``,

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -6,7 +6,7 @@
 
 .. _sec:key_commands:
 
-{Singularity} 3.2 introduces the abilities to import, export and remove
+{Singularity} has the ability to import, export and remove
 PGP keys following the OpenPGP standard via `GnuPGP (GPG)
 <https://www.gnupg.org/gph/en/manual.html>`_. These commands only modify
 the local keyring and are not related to the cloud keystore.
@@ -14,11 +14,11 @@ the local keyring and are not related to the cloud keystore.
 .. _key_import:
 
 ******************************
- Changes in {Singularity} 3.7
+ Global keyring
 ******************************
 
-{Singularity} 3.7 introduces a global keyring which can be managed by
-administrators with the new ``--global`` option. This global keyring is
+{Singularity} has a global keyring which can be managed by
+administrators with the ``--global`` option. This global keyring is
 used by ECL
 ({admindocs}/configfiles.html#ecl-toml)
 and allows administrators to manage public keys used during ECL image
@@ -28,7 +28,7 @@ verification.
  Key import command
 ********************
 
-{Singularity} 3.2 allows you import keys reading either from binary or
+{Singularity} allows you to import keys reading either from binary or
 armored key format and automatically detect if it is a private or public
 key and add it to the correspondent local keystore.
 

--- a/networking.rst
+++ b/networking.rst
@@ -18,7 +18,7 @@ configure a virtualized network for a container.
    default. Unrestricted ability to configure networking for containers
    would allow users to affect networking on the host, or in a cluster.
 
-   {Singularity} 3.8 allows the administrator to permit a list of
+   {Singularity} allows the administrator to permit a list of
    unprivileged users and/or groups to use specified network
    configurations. This is accomplished through settings in
    ``singularity.conf``. See the administrator guide for details.

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -284,7 +284,7 @@ To pass the ``--containall`` option to the ``run`` command and run a
 
    $ singularity run --containall library://lolcow
 
-{Singularity} 2.4 introduced the concept of command groups. For
+{Singularity} has the concept of command groups. For
 instance, to list Linux capabilities for a particular user, you would
 use the ``list`` command in the ``capability`` command group like so:
 
@@ -583,7 +583,7 @@ do with normal Linux commands.
 
 .. _sec:buildimagesfromscratch:
 
-{Singularity} v3.0 and above produces immutable images in the
+{Singularity} produces immutable images in the
 Singularity Image File (SIF) format. This ensures reproducible and
 verifiable images and allows for many extra benefits such as the ability
 to sign and verify your containers.

--- a/running_services.rst
+++ b/running_services.rst
@@ -21,7 +21,7 @@ isolated version of the container image that runs in the background.
 
 .. _sec:instances:
 
-{Singularity} v2.4 introduced the concept of *instances* allowing users
+{Singularity} has the concept of *instances* allowing users
 to run services in {Singularity}. This page will help you understand
 instances using an elementary example followed by a more useful example
 running an NGINX web server using instances. In the end, you will find a

--- a/security_options.rst
+++ b/security_options.rst
@@ -6,8 +6,8 @@
 
 .. _sec:security_options:
 
-{Singularity} 3.0 introduces many new security related options to the
-container runtime. This document will describe the new methods users
+{Singularity} implements security related options in the
+container runtime. This document describes the methods users
 have for specifying the security scope and context when running
 {Singularity} containers.
 
@@ -116,7 +116,7 @@ details.
  Security related action options
 *********************************
 
-{Singularity} 3.0 introduces many new flags that can be passed to the
+{Singularity} has many security related flags that can be passed to the
 action commands; ``shell``, ``exec``, and ``run`` allowing fine grained
 control of security.
 

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -6,7 +6,7 @@
 
 .. _sec:signnverify:
 
-{Singularity} 3.0 introduced the ability to create and manage PGP keys
+{Singularity} has the ability to create and manage PGP keys
 and use them to sign and verify containers. This provides a trusted
 method for {Singularity} users to share containers. It ensures a
 bit-for-bit reproduction of the original container as the author
@@ -14,11 +14,8 @@ intended it.
 
 .. note::
 
-   {Singularity} 3.6.0 uses a new signature format. Containers signed by
-   3.6.0 cannot be verifed by older versions of {Singularity}.
-
-   To verify containers signed with older versions of {Singularity}
-   using 3.6.0 the ``--legacy-insecure`` flag must be provided to the
+   To verify containers signed with Singularity versions older than
+   3.6.0 the ``--legacy-insecure`` flag must be provided to the
    ``singularity verify`` command.
 
 .. _verify_container_from_library:


### PR DESCRIPTION
This removes references to older singularity versions.  Based on #14.
- Fixes #3