### PR TITLE
Update apt repositories during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           go-version: 1.17.3
 
+      - name: Update repositories
+        run: |
+          sudo apt update
+
       - name: Install Apptainer dependencies
         run: |
           sudo apt-get install -f -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev cryptsetup-bin libgpgme-dev


### PR DESCRIPTION
This should fix 404 errors from Ubuntu package mirrors during publish.