### PR TITLE
Remove refs to HPCng 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -43,9 +43,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Singularity User Guide'
-author = u'Singularity Project Contributors'
-copyright = u'2017-2021, HPCng'
+project = u'Apptainer User Guide'
+author = u'ApptainerProject Contributors'
+copyright = u'2021-2022, Apptainer'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/conf.py
+++ b/conf.py
@@ -44,8 +44,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Apptainer User Guide'
-author = u'ApptainerProject Contributors'
-copyright = u'2021-2022, Apptainer'
+author = u'Apptainer Project Contributors'
+copyright = u'2021-2022, Apptainer a Series of LF Projects LLC'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/contributing.rst
+++ b/contributing.rst
@@ -29,8 +29,8 @@ help out other users!
 ======================
 
 Many of our users come to Slack for quick help with an issue. You can
-find us at `singularity-container
-<https://singularity-container.slack.com/>`_.
+find us at `apptainer
+<https://apptainer.slack.com/>`_.
 
 .. _contributing-to-documentation:
 
@@ -41,11 +41,11 @@ find us at `singularity-container
 ****************
 
 For general bugs/issues, you can open an issue `at the GitHub repo
-<https://github.com/hpcng/singularity/issues/new>`_. However, if you
+<https://github.com/apptainer/apptainer/issues/new>`_. However, if you
 find a security related issue/problem, please email the Singularity Security Team directly at
 singularity-security@hpcng.org. More information about the Singularity security policies
 and procedures can be found `here
-<https://singularity.hpcng.org/security-policy/>`__
+<https://apptainer.org/security-policy/>`__
 
 *********************
  Write Documentation
@@ -58,11 +58,11 @@ want to share the love so nobody feels left out!
 
 You can contribute to the documentation by `raising an issue to suggest
 an improvement
-<https://github.com/hpcng/singularity-userdocs/issues/new>`_ or by
+<https://github.com/apptainer/apptainer-userdocs/issues/new>`_ or by
 sending a `pull request
-<https://github.com/hpcng/singularity-userdocs/compare>`_ on `our
+<https://github.com/apptainer/apptainer-userdocs/compare>`_ on `our
 repository for documentation
-<https://github.com/hpcng/singularity-userdocs>`_.
+<https://github.com/apptainer/apptainer-userdocs>`_.
 
 The current documentation is generated with:
 
@@ -77,7 +77,7 @@ Other dependencies include:
 More information about contributing to the documentation, instructions
 on how to install the dependencies, and how to generate the files can be
 obtained `here
-<https://github.com/hpcng/singularity-userdocs/blob/master/README.md>`__.
+<https://github.com/apptainer/apptainer-userdocs/blob/master/README.md>`__.
 
 For more information on using Git and GitHub to create a pull request
 suggesting additions and edits to the docs, see the :ref:`section on
@@ -96,15 +96,15 @@ that you fork the main repo, create a new branch to make changes, and
 submit a pull request (PR) to the master branch.
 
 Check out our official `CONTRIBUTING.md
-<https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md>`_
+<https://github.com/apptainer/apptainer/blob/master/CONTRIBUTING.md>`_
 document, which also includes a `code of conduct
-<https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md#code-of-conduct>`_.
+<https://github.com/apptainer/apptainer/blob/master/CONTRIBUTING.md#code-of-conduct>`_.
 
 Step 1. Fork the repo
 =====================
 
 To contribute to {Singularity}, you should obtain a GitHub account and
-fork the `{Singularity} <https://github.com/hpcng/singularity>`_
+fork the `{Singularity} <https://github.com/apptainer/apptainer>`_
 repository. Once forked, clone your fork of the repo to your computer.
 (Obviously, you should replace ``your-username`` with your GitHub
 username.)

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -34,7 +34,7 @@ A {Singularity} Definition file is divided into two parts:
    to be executed at runtime can accept options intended for ``/bin/sh``
 
 For more in-depth and practical examples of def files, see the `Singularity
-examples repository <https://github.com/hpcng/singularity/tree/master/examples>`_
+examples repository <https://github.com/apptainer/apptainer/tree/master/examples>`_
 
 For a comparison between Dockerfile and {Singularity} definition file,
 please see: :ref:`this section <sec:deffile-vs-dockerfile>`.

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -18,7 +18,7 @@ If you need to request an installation on your shared resource, see the
 information to send to your system administrator.
 
 For any additional help or support contact the Singularity Community:
-https://singularity.hpcng.org/help
+https://apptainer.org/help
 
 .. _quick-installation:
 
@@ -132,14 +132,14 @@ Download {Singularity} from a release
 
 You can download {Singularity} from one of the releases. To see a full
 list, visit `the GitHub release page
-<https://github.com/hpcng/singularity/releases>`_. After deciding on a
+<https://github.com/apptainer/apptainer/releases>`_. After deciding on a
 release to install, you can run the following commands to proceed with
 the installation.
 
 .. code::
 
    $ export VERSION={InstallationVersion} && # adjust this as necessary \
-       wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+       wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
        tar -xzf singularity-${VERSION}.tar.gz && \
        cd singularity-${VERSION}
 
@@ -710,7 +710,7 @@ using the `Remote Builder <https://cloud.sylabs.io/builder>`_.
 This quickstart document just scratches the surface of all of the things
 you can do with {Singularity}!
 
-If you need additional help or support, see https://singularity.hpcng.org/help.
+If you need additional help or support, see https://apptainer.org/help.
 
 .. _installation-request:
 
@@ -731,7 +731,7 @@ similar to this:
 
    Dear shared resource administrator,
 
-   We are interested in having {Singularity} (https://singularity.hpcng.org)
+   We are interested in having {Singularity} (https://apptainer.org)
    installed on our shared resource. {Singularity} containers will allow us to
    build encapsulated environments, meaning that our work is reproducible and
    we are empowered to choose all dependencies including libraries, operating
@@ -764,7 +764,7 @@ similar to this:
        {admindocs}/installation.html
 
    If you have questions about any of the above, you can contact one of the
-   sources listed at https://singularity.hpcng.org/help. I can do my best
+   sources listed at https://apptainer.org/help. I can do my best
    to facilitate this interaction if help is needed.
 
    Thank you kindly for considering this request!

--- a/security.rst
+++ b/security.rst
@@ -11,8 +11,8 @@
 If you suspect you have found a vulnerability in {Singularity} we want
 to work with you so that it can be investigated, fixed, and disclosed in
 a responsible manner. Please follow the steps in our published `Security
-Policy <https://singularity.hpcng.org/security-policy/>`__, which begins with
-contacting us privately via singularity‑security@hpcng.org
+Policy <https://apptainer.org/security-policy/>`__, which begins with
+contacting us privately via security@apptainer.org
 
 We disclose vulnerabilities found in {Singularity} through public
 CVE reports, and notifications on our community channels. We encourage


### PR DESCRIPTION
## Description of the Pull Request (PR):

Wipes out references to HPCng and points to Apptainer.

## This fixes or addresses the following GitHub issues:

- Fixes #18 
