### PR TITLE
Remove refs for remote builder

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -45,9 +45,6 @@ below with their respective functionality.
 #. **SINGULARITY_BOOT**: Set to false by default, considers if executing
    ``/sbin/init`` when container boots (root only).
 
-#. **SINGULARITY_BUILDER**: To specify the remote builder service URL.
-   Defaults to our remote builder.
-
 ``C``
 =====
 

--- a/appendix.rst
+++ b/appendix.rst
@@ -73,10 +73,6 @@ below with their respective functionality.
 
 #. **SINGULARITY_DESC**: Contains a description of the capabilities.
 
-#. **SINGULARITY_DETACHED**: To submit a build job and print the build
-   ID (no real-time logs and also requires ``--remote``). Default is set
-   to false.
-
 #. **SINGULARITY_DISABLE_CACHE**: To disable all caching of docker/oci,
    library, oras, etc. downloads and built SIFs. Default is set to
    false.
@@ -251,9 +247,8 @@ below with their respective functionality.
 ``R``
 =====
 
-#. **SINGULARITY_REMOTE**: To build an image remotely. (Does not require
-   root) Default is set to false.
 #. **SINGULARITY_ROOTFS**: To reference the system file location.
+
 #. **SINGULARITY_RUNSCRIPT**: Specifies the runscript of the image.
 
 ``S``

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -177,15 +177,6 @@ present on disk or in memory. See :ref:`encrypted containers
  Build options
 ***************
 
-``--builder``
-=============
-
-{Singularity} gives the option to perform a remote build. The
-``--builder`` option allows you to specify a URL to a different build
-service. For instance, you may need to specify a URL to build to an on
-premises installation of the remote builder. This option must be used in
-conjunction with ``--remote``.
-
 ``--detached``
 ==============
 
@@ -251,13 +242,6 @@ container file system at build time. See :ref:`encrypted containers
 This flag allows you to pass the location of a public key to encrypt the
 container file system at build time. See :ref:`encrypted containers
 <encryption>` for more details.
-
-``--remote``
-============
-
-{Singularity} includes the ability to build a container on an
-external resource running a remote builder. (The default remote builder
-is located at "https://cloud.sylabs.io/builder".)
 
 ``--sandbox``
 =============
@@ -367,11 +351,6 @@ of the build do not use this temporary filesystem.
 
 -  If you want to make internally **modular containers**, check out the
    getting started guide `here <https://sci-f.github.io/tutorials>`_
-
--  If you want to **build your containers** on the Remote Builder,
-   (because you don’t have root access on a Linux machine or want to
-   host your container on the cloud) check out `this site
-   <https://cloud.sylabs.io/builder>`_
 
 -  If you want to **build a container with an encrypted file system**
    look :ref:`here <encryption>`.

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -177,14 +177,6 @@ present on disk or in memory. See :ref:`encrypted containers
  Build options
 ***************
 
-``--detached``
-==============
-
-When used in combination with the ``--remote`` option, the
-``--detached`` option will detach the build from your terminal and allow
-it to build in the background without echoing any output to your
-terminal.
-
 ``--encrypt``
 =============
 

--- a/build_env.rst
+++ b/build_env.rst
@@ -304,9 +304,6 @@ typically for use of a local registry.
 Library
 -------
 
-**SINGULARITY_BUILDER** Used to specify the remote builder service URL.
-The default value is our remote builder.
-
 **SINGULARITY_LIBRARY** Used to specify the library to pull from.
 Default is set to our Cloud Library.
 

--- a/cloud_library.rst
+++ b/cloud_library.rst
@@ -12,11 +12,6 @@ The Sylabs Cloud Library is the place to :ref:`push <push>` your
 containers to the cloud so other users can :ref:`pull <pull>`,
 :ref:`verify <signNverify>`, and use them.
 
-The Sylabs Cloud also provides a :ref:`Remote Builder <remote_builder>`,
-allowing you to build containers on a secure remote service. This is
-convenient so that you can build containers on systems where you do not
-have root privileges.
-
 .. _make_a_account:
 
 *****************
@@ -37,7 +32,7 @@ Making an account is easy, and straightforward:
  Creating a Access token
 *************************
 
-Access tokens for pushing a container, and remote builder.
+Access tokens for pushing a container.
 
 To generate a access token, do the following steps:
 
@@ -273,20 +268,6 @@ You can also limit results to only signed containers with the
                Signed by: 9FF48D6202271D3C842C53BD0D237BE8BB5B5C76
        ...
 
-.. _remote_builder:
-
-****************
- Remote Builder
-****************
-
-The remote builder service can build your container in the cloud
-removing the requirement for root access.
-
-Here's a typical remote build command:
-
-.. code::
-
-   $ singularity build --remote file-out.sif docker://ubuntu:18.04
 
 Building from a definition file:
 ================================
@@ -320,7 +301,4 @@ After building, you can test your container like so:
    $ ./ubuntu.sif
    hello world from ubuntu container!
 
-You can also use the web GUI to build containers remotely. First, go to
-https://cloud.sylabs.io/builder (make sure you are signed in). Then you
-can copy and paste, upload, or type your definition file. When you are
-finished, click build. Then you can download the container with the URL.
+

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -8,8 +8,8 @@
 
 The ``remote`` command group allows users to manage the service
 endpoints {Singularity} will interact with for many common command
-flows. This includes managing credentials for image storage services,
-remote builders, and key servers used to locate public keys for SIF
+flows. This includes managing credentials for image storage services
+and key servers used to locate public keys for SIF
 image verification. Currently, there are three main types of remote
 endpoints managed by this command group: the public Sylabs Cloud (or
 local {Singularity} Enterprise installation), OCI registries and
@@ -20,8 +20,7 @@ keyservers.
 *********************
 
 Sylabs introduced the online `Sylabs Cloud
-<https://cloud.sylabs.io/home>`_ to enable users to `Create
-<https://cloud.sylabs.io/builder>`_, `Secure
+<https://cloud.sylabs.io/home>`_ to enable users to `Secure
 <https://cloud.sylabs.io/keystore?sign=true>`_, and `Share
 <https://cloud.sylabs.io/library>`_ their container images with others.
 
@@ -316,8 +315,6 @@ If you do not want to switch remote with ``remote use`` you can:
 
 -  Make ``push`` and ``pull`` use an alternative library server with the
    ``--library`` option.
--  Make ``build --remote`` use an alternative remote builder with the
-   ``--builder`` option.
 -  Make ``keys`` use an alternative keyserver with the ``-url`` option.
 
 **************************

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -739,10 +739,6 @@ from Docker Hub and use images directly from official repositories such
 as Ubuntu, Debian, CentOS, Arch, and BusyBox. You can also use an
 existing container on your host system as a base.
 
-If you want to build {Singularity} images but you don't have
-administrative (root) access on your build system, you can build images
-using the `Remote Builder <https://cloud.sylabs.io/builder>`_.
-
 This quickstart document just scratches the surface of all of the things
 you can do with {Singularity}!
 


### PR DESCRIPTION
Signed-off-by: Pedro Alves Batista <pedro.pesquisapb@gmail.com>

## Description of the Pull Request (PR):

Takes off references to Remote Builder.

## This fixes or addresses the following GitHub issues:

- Fixes #19
