### PR TITLE
Change {Singularity} replacement to {Project} and set it to Apptainer

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -10,10 +10,10 @@
 .. _singularity-environment-variables:
 
 ***************************************
- {Singularity}'s environment variables
+ {Project}'s environment variables
 ***************************************
 
-{Singularity} comes with some environment variables you can set or
+{Project} comes with some environment variables you can set or
 modify depending on your needs. You can see them listed alphabetically
 below with their respective functionality.
 
@@ -68,7 +68,7 @@ below with their respective functionality.
 ``D``
 =====
 
-#. **SINGULARITY_DEFFILE**: Shows the {Singularity} recipe that was used
+#. **SINGULARITY_DEFFILE**: Shows the {Project} recipe that was used
    to generate the image.
 
 #. **SINGULARITY_DESC**: Contains a description of the capabilities.
@@ -309,8 +309,8 @@ below with their respective functionality.
 
 #. **SINGULARITY_USERNS** and **SINGULARITY_UNSHARE_USERNS**: To specify
    that the container will run in a new user namespace, allowing
-   {Singularity} to run completely unprivileged on recent kernels. This
-   may not support every feature of {Singularity}. (Sandbox image only).
+   {Project} to run completely unprivileged on recent kernels. This
+   may not support every feature of {Project}. (Sandbox image only).
    Default is set to false.
 
 ``W``
@@ -320,7 +320,7 @@ below with their respective functionality.
    ``/tmp``, ``/var/tmp`` and ``$HOME`` (if ``-c`` or ``--contain`` was
    also used)
 
-#. **SINGULARITY_WRITABLE**: By default, all {Singularity} containers
+#. **SINGULARITY_WRITABLE**: By default, all {Project} containers
    are available as read only, this option makes the file system
    accessible as read/write. Default set to false.
 
@@ -403,7 +403,7 @@ Overview
 Docker images are comprised of layers that are assembled at runtime to
 create an image. You can use Docker layers to create a base image, and
 then add your own custom software. For example, you might use Docker’s
-Ubuntu image layers to create an Ubuntu {Singularity} container. You
+Ubuntu image layers to create an Ubuntu {Project} container. You
 could do the same with CentOS, Debian, Arch, Suse, Alpine, BusyBox, etc.
 
 Or maybe you want a container that already has software installed. For
@@ -414,7 +414,7 @@ software on top of that.
 
 Or perhaps you have already invested in Docker and created your own
 Docker containers. If so, you can seamlessly convert them to
-{Singularity} with the ``docker`` bootstrap module.
+{Project} with the ``docker`` bootstrap module.
 
 Keywords
 --------
@@ -436,7 +436,7 @@ a base. ``registry`` is optional and defaults to ``index.docker.io``.
 correct namespace to use for some official containers (ubuntu for
 example). ``tag`` is also optional and will default to ``latest``
 
-See :ref:`{Singularity} and Docker <singularity-and-docker>` for more
+See :ref:`{Project} and Docker <singularity-and-docker>` for more
 detailed info on using Docker registries.
 
 .. code:: singularity
@@ -512,7 +512,7 @@ Notes
 When bootstrapping from a Singularity Hub image, all previous definition
 files that led to the creation of the current image will be stored in a
 directory within the container called
-``/.singularity.d/bootstrap_history``. {Singularity} will also alert you
+``/.singularity.d/bootstrap_history``. {Project} will also alert you
 if environment variables have been changed between the base image and
 the new image during bootstrap.
 
@@ -561,7 +561,7 @@ you want to use.
 .. _sec:build-localimage:
 
 This module allows you to build a container from an existing
-{Singularity} container on your host system. The name is somewhat
+{Project} container on your host system. The name is somewhat
 misleading because your container can be in either image or directory
 format.
 
@@ -610,7 +610,7 @@ Notes
 When building from a local container, all previous definition files that
 led to the creation of the current container will be stored in a
 directory within the container called
-``/.singularity.d/bootstrap_history``. {Singularity} will also alert you
+``/.singularity.d/bootstrap_history``. {Project} will also alert you
 if environment variables have been changed between the base image and
 the new image during bootstrap.
 
@@ -796,7 +796,7 @@ need to perform a significant amount of configuration to get a usable
 OS. Please refer to this `README.md
 <https://github.com/singularityware/singularity/blob/master/examples/arch/README.md>`_
 and the `Arch Linux example
-<https://github.com/singularityware/singularity/blob/master/examples/arch/Singularity>`_
+<https://github.com/singularityware/singularity/blob/master/examples/arch/{Project}>`_
 for more info.
 
 .. _build-busybox:
@@ -850,7 +850,7 @@ URI.
 .. note::
 
    ``zypper`` version 1.11.20 or greater is required on the host system,
-   as {Singularity} requires the ``--releasever`` flag.
+   as {Project} requires the ``--releasever`` flag.
 
 Overview
 --------
@@ -892,7 +892,7 @@ install when using the zypper build module is ``zypper`` itself.
 =========================================================
 
 If you are using docker locally there are two options for creating
-{Singularity} images without the need for a repository. You can either
+{Project} images without the need for a repository. You can either
 build a SIF from a ``docker-save`` tar file or you can convert any
 docker image present in docker's daemon internal storage.
 
@@ -918,7 +918,7 @@ currently residing in docker's daemon internal storage:
    Storing signatures
    2019/12/11 14:53:24  info unpack layer: sha256:eb7c47c7f0fd0054242f35366d166e6b041dfb0b89e5f93a82ad3a3206222502
    INFO:    Creating SIF file...
-   Singularity>
+   {Project}>
 
 while ``docker-archive`` permits you to do the same thing starting from
 a docker image stored in a ``docker-save`` formatted tar file:
@@ -937,12 +937,12 @@ a docker image stored in a ``docker-save`` formatted tar file:
    Storing signatures
    2019/12/11 15:25:09  info unpack layer: sha256:eb7c47c7f0fd0054242f35366d166e6b041dfb0b89e5f93a82ad3a3206222502
    INFO:    Creating SIF file...
-   Singularity>
+   {Project}>
 
 Keywords
 --------
 
-The ``docker-daemon`` bootstrap agent can be used in a {Singularity}
+The ``docker-daemon`` bootstrap agent can be used in a {Project}
 definition file as follows:
 
 .. code:: singularity
@@ -1005,7 +1005,7 @@ The resulting container provides a shell, and is 696KiB in size:
    $ singularity run scratch.sif
    WARNING: passwd file doesn't exist in container, not updating
    WARNING: group file doesn't exist in container, not updating
-   Singularity> echo "Hello from a 696KiB container"
+   {Project}> echo "Hello from a 696KiB container"
    Hello from a 696KiB container
 
 Keywords

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -8,7 +8,7 @@
 
 Unless `disabled by the system administrator
 <{admindocs}/configfiles.html#bind-mount-management>`_,
-{Singularity} allows you to map directories on your host system to
+{Project} allows you to map directories on your host system to
 directories within your container using bind mounts. This allows you to
 read and write data on the host system with ease.
 
@@ -16,10 +16,10 @@ read and write data on the host system with ease.
  Overview
 **********
 
-When {Singularity} ‘swaps’ the host operating system for the one inside
+When {Project} ‘swaps’ the host operating system for the one inside
 your container, the host file systems becomes inaccessible. However, you
 may want to read and write files on the host system from within the
-container. To enable this functionality, {Singularity} will bind
+container. To enable this functionality, {Project} will bind
 directories back into the container via two primary methods:
 system-defined bind paths and user-defined bind paths.
 
@@ -30,7 +30,7 @@ system-defined bind paths and user-defined bind paths.
 The system administrator has the ability to define what bind paths will
 be included automatically inside each container. Some bind paths are
 automatically derived (e.g. a user’s home directory) and some are
-statically defined (e.g. bind paths in the {Singularity} configuration
+statically defined (e.g. bind paths in the {Project} configuration
 file). In the default configuration, the system default bind points are
 ``$HOME`` , ``/sys:/sys`` , ``/proc:/proc``, ``/tmp:/tmp``,
 ``/var/tmp:/var/tmp``, ``/etc/resolv.conf:/etc/resolv.conf``,
@@ -45,7 +45,7 @@ The ``--no-mount`` flag allows specific
 system mounts to be disabled, even if they are set in the
 ``singularity.conf`` configuration file by the administrator.
 
-For example, if {Singularity} has been configured with ``mount hostfs =
+For example, if {Project} has been configured with ``mount hostfs =
 yes`` then every filesystem on the host will be bind mounted to the
 container by default. If, e.g. a ``/project`` filesystem on your host
 conflicts with a ``/project`` directory in the container you are
@@ -71,7 +71,7 @@ Unless the system administrator has `disabled user control of binds
 <{admindocs}/configfiles.html#bind-mount-management>`_,
 you will be able to request your own bind paths within your container.
 
-The {Singularity} action commands (``run``, ``exec``, ``shell``, and
+The {Project} action commands (``run``, ``exec``, ``shell``, and
 ``instance start``) will accept the ``--bind/-B`` command-line option to
 specify bind paths, and will also honor the ``$SINGULARITY_BIND`` (or
 ``$SINGULARITY_BINDPATH``) environment variable. The argument for this
@@ -83,7 +83,7 @@ specified as ``ro`` (read-only) or ``rw`` (read/write, which is the
 default). The ``--bind/-B`` option can be specified multiple times, or a
 comma-delimited string of bind path specifications can be used.
 
-{Singularity} also has a ``--mount`` flag, which provides a
+{Project} also has a ``--mount`` flag, which provides a
 longer-form method of specifying binds in ``--mount
 type=bind,src=<source>,dst=<destination>[,<option>]...`` format. This is
 compatible with the ``--mount`` syntax for binds in Docker and other OCI
@@ -124,7 +124,7 @@ this would be:
 
 Using the environment variable ``$SINGULARITY_BIND``, you can bind paths
 even when you are running your container as an executable file with a
-runscript. If you bind many directories into your {Singularity}
+runscript. If you bind many directories into your {Project}
 containers and they don’t change, you could even benefit by setting this
 variable in your ``.bashrc`` file.
 
@@ -135,7 +135,7 @@ The ``--mount`` flag takes a mount specification in the format
 ``type=bind,src=<source>,dst=<dest>``. Additional options can be
 specified, comma delimited.
 
-{Singularity} only supports the ``bind`` type for ``--mount``, and will
+{Project} only supports the ``bind`` type for ``--mount``, and will
 infer ``type=bind`` if it is not provided.
 
 ``src`` or ``source`` can be used interchangeably. ``dst``,
@@ -198,12 +198,12 @@ Using ``--bind`` or ``-mount`` with the ``--writable`` flag
 
 To mount a bind path inside the container, a *bind point* must be
 defined within the container. The bind point is a directory within the
-container that {Singularity} can use as a destination to bind a
+container that {Project} can use as a destination to bind a
 directory on the host system.
 
-{Singularity} will do its best to bind mount
+{Project} will do its best to bind mount
 requested paths into a container regardless of whether the appropriate
-bind point exists within the container. {Singularity} can often carry
+bind point exists within the container. {Project} can often carry
 out this operation even in the absence of the "overlay fs" feature.
 
 However, binding paths to non-existent points within the container can
@@ -220,7 +220,7 @@ Using ``--no-home`` and ``--containall`` flags
 ``--no-home``
 -------------
 
-When shelling into your container image, {Singularity} allows you to
+When shelling into your container image, {Project} allows you to
 mount your current working directory (``CWD``) without mounting your
 host ``$HOME`` directory with the ``--no-home`` flag.
 
@@ -264,7 +264,7 @@ mount a remote computer's filesystem to your local host, over ssh:
    # Now mounted to my local machine:
    $ ythel:/home/dave on /home/dave/other_host type fuse.sshfs (rw,nosuid,nodev,relatime,user_id=1000,group_id=1000)
 
-{Singularity} has a ``--fusemount`` option, which allows
+{Project} has a ``--fusemount`` option, which allows
 you to directly expose FUSE filesystems inside a container. The FUSE
 command / driver that mounts a particular type of filesystem can be
 located on the host, or in the container.
@@ -273,8 +273,8 @@ Requirements
 ============
 
 The FUSE command *must* be based on libfuse3 3.3.0 or greater to work
-correctly with {Singularity}. Older versions do not support the way in
-which the {Singularity} runtime passes a pre-mounted file descriptor
+correctly with {Project}. Older versions do not support the way in
+which the {Project} runtime passes a pre-mounted file descriptor
 into the container.
 
 If you are using an older distribution that provides FUSE commands such
@@ -282,13 +282,13 @@ as ``sshfs`` based on FUSE 2 then you can install FUSE 3 versions of the
 commands you need inside your container. EL7 distributions can install a
 compatible version of FUSE 3 from the EPEL repository. EL8 distributions
 ship FUSE 3.2.1 as a base package. Unfortunately this is an older version
-which does not fully support the way in which {Singularity} prepares FUSE
+which does not fully support the way in which {Project} prepares FUSE
 mounts.
 
 FUSE mount definitions
 ======================
 
-A fusemount definition for {Singularity} consists of 3 parts:
+A fusemount definition for {Project} consists of 3 parts:
 
 .. code::
 
@@ -329,9 +329,9 @@ type:
 .. code::
 
    $ singularity run --fusemount "host:sshfs server:/ /server" docker://ubuntu
-   Singularity> cat /etc/hostname
+   {Project}> cat /etc/hostname
    localhost.localdomain
-   Singularity> cat /server/etc/hostname
+   {Project}> cat /server/etc/hostname
    server
 
 FUSE mount with a container executable
@@ -343,16 +343,16 @@ added to your container, you can use the ``container`` mount type:
 .. code::
 
    $ singularity run --fusemount "container:sshfs server:/ /server" sshfs.sif
-   Singularity> cat /etc/hostname
+   {Project}> cat /etc/hostname
    localhost.localdomain
-   Singularity> cat /server/etc/hostname
+   {Project}> cat /server/etc/hostname
    server
 
 **************
  Image Mounts
 **************
 
-In {Singularity} you can mount a directory contained in an
+In {Project} you can mount a directory contained in an
 image file into a container. This may be useful if you want to
 distribute directories containing a large number of data files as a
 single image file.
@@ -409,10 +409,10 @@ wish to distribute in an image file that allows read/write:
    Copying files into the device: done
    Writing superblocks and filesystem accounting information: done
 
-   # Run {Singularity}, mounting my input data to '/input-data' in
+   # Run {Project}, mounting my input data to '/input-data' in
    # the container.
    $ singularity run -B inputs.img:/input-data:image-src=/ mycontainer.sif
-   Singularity> ls /input-data
+   {Project}> ls /input-data
    1           3           5           7           9
    2           4           6           8           lost+found
 
@@ -437,10 +437,10 @@ then the squashfs format is appropriate:
    Creating 4.0 filesystem on inputs.squashfs, block size 131072.
    ...
 
-   # Run {Singularity}, mounting my input data to '/input-data' in
+   # Run {Project}, mounting my input data to '/input-data' in
    # the container.
    $ singularity run -B inputs.squashfs:/input-data:image-src=/ mycontainer.sif
-   Singularity> ls /input-data/
+   {Project}> ls /input-data/
    1  2  3  4  5  6  7  8  9
 
    # Or with --mount instead of -B
@@ -464,9 +464,9 @@ instructions <overlay-sif>`:
    # Add the squashfs data image from above to the SIF
    $ singularity sif add --datatype 4 --partarch 2 --partfs 1 --parttype 3 inputs.sif inputs.squashfs
 
-   # Run {Singularity}, binding data from the SIF file
+   # Run {Project}, binding data from the SIF file
    $ singularity run -B inputs.sif:/input-data:image-src=/ mycontainer.sif
-   Singularity> ls /input-data
+   {Project}> ls /input-data
    1  2  3  4  5  6  7  8  9
 
    # Or with --mount instead of -B
@@ -474,6 +474,6 @@ instructions <overlay-sif>`:
        --mount type=bind,src=inputs.sif,dst=/input-data,image-src=/ \
        mycontainer.sif
 
-If your bind source is a SIF then {Singularity} will bind from the first
+If your bind source is a SIF then {Project} will bind from the first
 data partition in the SIF, or you may specify an alternative descriptor
 by ID with the additional option ``id=n``, where n is the descriptor ID.

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -10,8 +10,8 @@
 it to download and assemble existing containers from external resources
 like the `Container Library <https://cloud.sylabs.io/library>`_ and
 `Docker Hub <https://hub.docker.com/>`_. You can use it to convert
-containers between the formats supported by {Singularity}. And you can
-use it in conjunction with a :ref:`{Singularity} definition
+containers between the formats supported by {Project}. And you can
+use it in conjunction with a :ref:`{Project} definition
 <definition-files>` file to create a container from scratch and
 customized it to fit your needs.
 
@@ -30,7 +30,7 @@ container. It can be one of the following:
 -  URI beginning with **shub://** to build from Singularity Hub
 -  path to a **existing container** on your local machine
 -  path to a **directory** to build from a sandbox
--  path to a :ref:`{Singularity} definition file <definition-files>`
+-  path to a :ref:`{Project} definition file <definition-files>`
 
 ``build`` can produce containers in two different formats that can be
 specified as follows.
@@ -66,7 +66,7 @@ container in a writable format use the ``--sandbox`` option.
 ***************************************************
 
 You can use ``build`` to download layers from Docker Hub and assemble
-them into {Singularity} containers.
+them into {Project} containers.
 
 .. code::
 
@@ -113,17 +113,17 @@ one format to another. For example if you had a sandbox container called
 
 Use care when converting a sandbox directory to the default SIF format.
 If changes were made to the writable container before conversion, there
-is no record of those changes in the {Singularity} definition file
+is no record of those changes in the {Project} definition file
 rendering your container non-reproducible. It is a best practice to
-build your immutable production containers directly from a {Singularity}
+build your immutable production containers directly from a {Project}
 definition file instead.
 
 *********************************************************
- Building containers from {Singularity} definition files
+ Building containers from {Project} definition files
 *********************************************************
 
-Of course, {Singularity} definition files can be used as the target when
-building a container. For detailed information on writing {Singularity}
+Of course, {Project} definition files can be used as the target when
+building a container. For detailed information on writing {Project}
 definition files, please see the :doc:`Container Definition docs
 <definition_files>`. Let’s say you already have the following container
 definition file called ``lolcow.def``, and you want to use it to build a
@@ -167,7 +167,7 @@ machine requires root privileges.
  Building encrypted containers
 *******************************
 
-With {Singularity} it is possible to build and run
+With {Project} it is possible to build and run
 encrypted containers. The containers are decrypted at runtime entirely
 in kernel space, meaning that no intermediate decrypted data is ever
 present on disk or in memory. See :ref:`encrypted containers
@@ -180,7 +180,7 @@ present on disk or in memory. See :ref:`encrypted containers
 ``--encrypt``
 =============
 
-Specifies that {Singularity} should use a secret saved in either the
+Specifies that {Project} should use a secret saved in either the
 ``SINGULARITY_ENCRYPTION_PASSPHRASE`` or
 ``SINGULARITY_ENCRYPTION_PEM_PATH`` environment variable to build an
 encrypted container. See :ref:`encrypted containers <encryption>` for
@@ -196,12 +196,12 @@ Gives users a way to build containers completely unprivileged. See
 ===========
 
 The ``--force`` option will delete and overwrite an existing
-{Singularity} image without presenting the normal interactive prompt.
+{Project} image without presenting the normal interactive prompt.
 
 ``--json``
 ==========
 
-The ``--json`` option will force {Singularity} to interpret a given
+The ``--json`` option will force {Project} to interpret a given
 definition file as a json.
 
 ``--library``
@@ -249,7 +249,7 @@ definition file sections. Acceptable arguments include ``all``, ``none``
 or any combination of the following: ``setup``, ``post``, ``files``,
 ``environment``, ``test``, ``labels``.
 
-Under normal build conditions, the {Singularity} definition file is
+Under normal build conditions, the {Project} definition file is
 saved into a container’s meta-data so that there is a record showing how
 the container was built. Using the ``--section`` option may render this
 meta-data useless, so use care if you value reproducibility.
@@ -265,7 +265,7 @@ By default if you build into an existing sandbox container, the
 ``build`` command will prompt you to decide whether or not to overwrite
 the container. Instead of this behavior you can use the ``--update``
 option to build _into_ an existing container. This will cause
-{Singularity} to skip the header and build any sections that are in the
+{Project} to skip the header and build any sections that are in the
 definition file into the existing container.
 
 The ``--update`` option is only valid when used with sandbox containers.
@@ -280,7 +280,7 @@ of ``post`` and ``test`` sections.
 .. note::
 
     This option can't be set via the environment variable `SINGULARITY_NV`.
-    Singularity will attempt to bind binaries listed in SINGULARITY_CONFDIR/nvliblist.conf,
+    {Project} will attempt to bind binaries listed in SINGULARITY_CONFDIR/nvliblist.conf,
     if the mount destination doesn't exist inside the container, they are ignored.
 
 ``--rocm``
@@ -293,7 +293,7 @@ your build environment. Libraries are mounted during the execution of
 .. note::
 
     This option can't be set via the environment variable `SINGULARITY_ROCM`.
-    Singularity will attempt to bind binaries listed in `SINGULARITY_CONFDIR/rocmliblist.conf`,
+    {Project} will attempt to bind binaries listed in `SINGULARITY_CONFDIR/rocmliblist.conf`,
     if the mount destination doesn't exist inside the container, they are ignored.
 
 ``--bind``

--- a/build_env.rst
+++ b/build_env.rst
@@ -21,7 +21,7 @@ other topics related to the build environment.
  Cache Folders
 ***************
 
-{Singularity} will cache SIF container images generated from remote
+{Project} will cache SIF container images generated from remote
 sources, and any OCI/docker layers used to create them. The cache is
 created at ``$HOME/.singularity/cache`` by default. The location of the
 cache can be changed by setting the ``SINGULARITY_CACHEDIR`` environment
@@ -58,11 +58,11 @@ location that is:
 
    If you are not certain that your ``$HOME`` or
    ``SINGULARITY_CACHEDIR`` filesystems support atomic rename, do not
-   run {Singularity} in parallel using remote container URLs. Instead
+   run {Project} in parallel using remote container URLs. Instead
    use ``singularity pull`` to create a local SIF image, and then run
    this SIF image in a parallel step. An alternative is to use the
    ``--disable-cache`` option, but this will result in each
-   {Singularity} instance independently fetching the container from the
+   {Project} instance independently fetching the container from the
    remote source, into a temporary location.
 
 Inside the cache location you will find separate directories for the
@@ -77,7 +77,7 @@ different kinds of data that are cached:
    $HOME/.singularity/cache/shub
 
 You can safely delete these directories, or content within them.
-{Singularity} will re-create any directories and data that are needed in
+{Project} will re-create any directories and data that are needed in
 future runs.
 
 You should not add any additional files, or modify files in the cache,
@@ -88,13 +88,13 @@ to reset the cache to a clean, empty state.
 BoltDB Corruption Errors
 ========================
 
-The library that {Singularity} uses to retrieve and cache Docker/OCI
+The library that {Project} uses to retrieve and cache Docker/OCI
 layers keeps track of them using a single file database. If your home
 directory is on a network filesystem which experiences interruptions, or
 you run out of storage, it is possible for this database to become
 inconsistent.
 
-If you observe error messages when trying to run {Singularity} that
+If you observe error messages when trying to run {Project} that
 mention `github.com/etcd-io/bbolt` then you should remove the database
 file:
 
@@ -106,7 +106,7 @@ file:
  Cache commands
 ****************
 
-The ``cache`` command for {Singularity} allows you to view and clean up
+The ``cache`` command for {Project} allows you to view and clean up
 your cache, without manually inspecting the cache directories.
 
 .. note::
@@ -178,7 +178,7 @@ You can limit the cache list to a specific cache type with the ``-type``
 Cleaning the Cache
 ==================
 
-To reclaim space used by the {Singularity} cache, use ``singularity
+To reclaim space used by the {Project} cache, use ``singularity
 cache clean``.
 
 By default ``singularity cache clean`` will remove all cache entries,
@@ -216,15 +216,15 @@ use the ``type`` / ``-T`` option:
  Temporary Folders
 *******************
 
-When building a container, or pulling/running a {Singularity} container
+When building a container, or pulling/running a {Project} container
 from a Docker/OCI source, a temporary working space is required. The
 container is constructed in this temporary space before being packaged
-into a {Singularity} SIF image. Temporary space is also used when
+into a {Project} SIF image. Temporary space is also used when
 running containers in unprivileged mode, and performing some operations
 on filesystems that do not fully support ``--fakeroot``.
 
 The location for temporary directories defaults to ``/tmp``.
-{Singularity} will also respect the environment variable ``TMPDIR``, and
+{Project} will also respect the environment variable ``TMPDIR``, and
 both of these locations can be overridden by setting the environment
 variable ``SINGULARITY_TMPDIR``.
 
@@ -254,7 +254,7 @@ Remember to use ``-E`` option to pass the value of
  Encrypted Containers
 **********************
 
-With {Singularity} it is possible to build and run
+With {Project} it is possible to build and run
 encrypted containers. The containers are decrypted at runtime entirely
 in kernel space, meaning that no intermediate decrypted data is ever
 present on disk or in memory. See :ref:`encrypted containers

--- a/cgroups.rst
+++ b/cgroups.rst
@@ -22,10 +22,10 @@ processes.
    https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 
 ***************************************
- Running {Singularity} Inside a Cgroup
+ Running {Project} Inside a Cgroup
 ***************************************
 
-Because {Singularity} starts a container as a simple process, rather
+Because {Project} starts a container as a simple process, rather
 than using a daemon, you can limit resource usage by running the
 ``singularity`` command inside an existing cgroup. This is convenient
 where, for example, a job scheduler uses cgroups to control job limits.
@@ -36,7 +36,7 @@ systemd-run
 ===========
 
 As well as schedulers you can use tools such as ``systemd-run`` to
-create a cgroup, and run {Singularity} inside of it. This is convenient
+create a cgroup, and run {Project} inside of it. This is convenient
 on modern cgroups v2 systems, where the creation of cgroups can be
 delegated to users through systemd. Without this delegation ``root``
 privileges are required to create a cgroup.
@@ -72,10 +72,10 @@ link below, which details the properties you can set using
 https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
 
 **************************************
- Using Singularity to Create a Cgroup
+ Using {Project} to Create a Cgroup
 **************************************
 
-{Singularity} allows you to directly apply resource limitations to
+{Project} allows you to directly apply resource limitations to
 systems configured for both cgroups v1 and the v2 unified hierarchy.
 Resource limits are specified using a TOML file that represents the
 `resources` section of the OCI runtime-spec:
@@ -91,7 +91,7 @@ eBPF programs that implement the requested access controls.
 
 .. note::
 
-   {Singularity} does not currently support applying native cgroups v2
+   {Project} does not currently support applying native cgroups v2
    ``unified`` resource limit specifications. Use the cgroups v1 limits,
    which will be translated to v2 format when applied on a cgroups v2
    system.
@@ -281,12 +281,12 @@ or write to ``/dev/null``:
 Other limits
 ------------
 
-{Singularity} can apply all resource limits that are valid in the OCI
+{Project} can apply all resource limits that are valid in the OCI
 runtime-spec ``resources`` section, **except** native ``unified``
 cgroups v2 constraints. Use the cgroups v1 limits, which will be
 translated to v2 format when applied on a cgroups v1 system.
 
 See
 https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#control-groups
-for information about the available limits. Note that {Singularity} uses
+for information about the available limits. Note that {Project} uses
 TOML format for the configuration file, rather than JSON.

--- a/cloud_library.rst
+++ b/cloud_library.rst
@@ -84,7 +84,7 @@ You can download the container with that tag by replacing the
 ``:latest``, with the tagged container you want to download.
 
 To set a description against the container image as you push it, use the
-`-D` flag introduced in {Singularity} 3.7. This provides an alternative
+`-D` flag introduced in {Project} 3.7. This provides an alternative
 to setting the description via the web interface:
 
 .. code:: console
@@ -95,7 +95,7 @@ to setting the description via the web interface:
    Library storage: using 13.24 MiB out of 11.00 GiB quota (0.1% used)
    Container URL: https://cloud.sylabs.io/library/myuser/examples/alpine
 
-Note that when you push to a library that supports it, {Singularity} 3.7
+Note that when you push to a library that supports it, {Project} 3.7
 and above will report your quota usage and the direct URL to view the
 container in your web browser.
 
@@ -127,7 +127,7 @@ Here's a typical pull command:
 
 .. note::
 
-   If there's no tag after the container name, {Singularity}
+   If there's no tag after the container name, {Project}
    automatically will pull the container with the ``:latest`` tag.
 
 To pull a container with a specific tag, just add the tag to the library

--- a/contributing.rst
+++ b/contributing.rst
@@ -4,7 +4,7 @@
  Contributing
 ##############
 
-{Singularity} is an open source project, meaning we have the challenge
+{Project} is an open source project, meaning we have the challenge
 of limited resources. We are grateful for any support that you can
 offer. Helping other users, raising issues, helping write documentation,
 or contributing code are all ways to help!
@@ -14,18 +14,18 @@ or contributing code are all ways to help!
 ********************
 
 This is a huge endeavor, and your help would be greatly appreciated!
-Post to online communities about {Singularity}, and request that your
+Post to online communities about {Project}, and request that your
 distribution vendor, service provider, and system administrators include
-{Singularity} for you!
+{Project} for you!
 
-{Singularity} Google Group
+{Project} Google Group
 ==========================
 
-If you have been using {Singularity} and having good luck with it, join
+If you have been using {Project} and having good luck with it, join
 our `Google Group <https://groups.google.com/g/singularity-ce>`_ and
 help out other users!
 
-{Singularity} on Slack
+{Project} on Slack
 ======================
 
 Many of our users come to Slack for quick help with an issue. You can
@@ -42,8 +42,8 @@ find us at `apptainer
 
 For general bugs/issues, you can open an issue `at the GitHub repo
 <https://github.com/apptainer/apptainer/issues/new>`_. However, if you
-find a security related issue/problem, please email the Singularity Security Team directly at
-singularity-security@hpcng.org. More information about the Singularity security policies
+find a security related issue/problem, please email the {Project} Security Team directly at
+security@apptainer.org. More information about the {Project} security policies
 and procedures can be found `here
 <https://apptainer.org/security-policy/>`__
 
@@ -103,8 +103,8 @@ document, which also includes a `code of conduct
 Step 1. Fork the repo
 =====================
 
-To contribute to {Singularity}, you should obtain a GitHub account and
-fork the `{Singularity} <https://github.com/apptainer/apptainer>`_
+To contribute to {Project}, you should obtain a GitHub account and
+fork the `{Project} <https://github.com/apptainer/apptainer>`_
 repository. Once forked, clone your fork of the repo to your computer.
 (Obviously, you should replace ``your-username`` with your GitHub
 username.)
@@ -186,8 +186,8 @@ Once you have pushed your branch, then you can go to your fork (in the
 web GUI on GitHub) and `submit a Pull Request
 <https://help.github.com/articles/creating-a-pull-request/>`_.
 Regardless of the name of your branch, your PR should be submitted to
-the Singularity ``master`` branch. Submitting your PR will open a
-conversation thread for the maintainers of {Singularity} to discuss your
+the {Project} ``master`` branch. Submitting your PR will open a
+conversation thread for the maintainers of {Project} to discuss your
 contribution. At this time, the continuous integration that is linked
 with the code base will also be executed. If there is an issue, or if
 the maintainers suggest changes, you can continue to push commits to
@@ -196,7 +196,7 @@ your branch and they will update the Pull Request.
 Step 6. Keep your branch in sync
 ================================
 
-Cloning the repo will create an exact copy of the {Singularity}
+Cloning the repo will create an exact copy of the {Project}
 repository at that moment. As you work, your branch may become out of
 date as others merge changes into the upstream master. In the event that
 you need to update a branch, you will need to follow the next steps:

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -6,7 +6,7 @@
 
 .. _sec:deffiles:
 
-A {Singularity} Definition File (or "def file" for short) is like a set
+A {Project} Definition File (or "def file" for short) is like a set
 of blueprints explaining how to build a custom container. It includes
 specifics about the base OS to build or the base container to start
 from, software to install, environment variables to set at runtime,
@@ -16,7 +16,7 @@ files to add from the host system, and container metadata.
  Overview
 **********
 
-A {Singularity} Definition file is divided into two parts:
+A {Project} Definition file is divided into two parts:
 
 #. **Header**: The Header describes the core operating system to build
    within the container. Here you will configure the base operating
@@ -33,10 +33,10 @@ A {Singularity} Definition file is divided into two parts:
    accept ``/bin/sh`` options. Similarly, sections that produce scripts
    to be executed at runtime can accept options intended for ``/bin/sh``
 
-For more in-depth and practical examples of def files, see the `Singularity
+For more in-depth and practical examples of def files, see the `{Project}
 examples repository <https://github.com/apptainer/apptainer/tree/master/examples>`_
 
-For a comparison between Dockerfile and {Singularity} definition file,
+For a comparison between Dockerfile and {Project} definition file,
 please see: :ref:`this section <sec:deffile-vs-dockerfile>`.
 
 ********
@@ -44,7 +44,7 @@ please see: :ref:`this section <sec:deffile-vs-dockerfile>`.
 ********
 
 The header should be written at the top of the def file. It tells
-{Singularity} about the base operating system that it should use to
+{Project} about the base operating system that it should use to
 build the container. It is composed of several keywords.
 
 The only keyword that is required for every type of build is
@@ -315,7 +315,7 @@ configuration process.
 =====
 
 In some circumstances, it may be redundant to build different containers
-for each app with nearly equivalent dependencies. {Singularity} supports
+for each app with nearly equivalent dependencies. {Project} supports
 installing apps within internal modules based on the concept of the
 `Scientific Filesystem (SCIF) <https://sci-f.github.io/>`_. More
 information on defining and using SCIF Apps :ref:`here <apps>`.
@@ -485,7 +485,7 @@ Note that variables added to the ``$SINGULARITY_ENVIRONMENT`` file in
 ``%environment`` section.
 
 See :ref:`Environment and Metadata <environment-and-metadata>` for more
-information about the {Singularity} container environment.
+information about the {Project} container environment.
 
 .. _startscript:
 
@@ -547,7 +547,7 @@ passed to the container at runtime are printed as a single string
 which ensures that all of the arguments are properly parsed by the
 executed command. The ``exec`` preceding the final ``echo`` command
 replaces the current entry in the process table (which originally was
-the call to {Singularity}). Thus the runscript shell process ceases to
+the call to {Project}). Thus the runscript shell process ceases to
 exist, and only the process running within the container remains.
 
 Running the container built using this def file will yield the
@@ -699,17 +699,17 @@ which to run easily. Each entry point can carry out a different task
 with its own environment, metadata etc., without the need for a
 collection of different containers.
 
-{Singularity} implements SCIF, and you can read more about how to use it
+{Project} implements SCIF, and you can read more about how to use it
 below.
 
-SCIF is not specific to {Singularity}. You can learn more about it at
+SCIF is not specific to {Project}. You can learn more about it at
 the project's site: https://sci-f.github.io/ which includes extended
 tutorials, the specification, and other information.
 
 SCIF %app* sections
 ===================
 
-SCIF apps within a {Singularity} container are created using ``%app*``
+SCIF apps within a {Project} container are created using ``%app*``
 sections in a definition file. These ``%app*`` sections, which will
 impact the way the container runs a specific ``--app`` can exist
 alongside any of the primary sections (i.e. ``%post``,``%runscript``,

--- a/encryption.rst
+++ b/encryption.rst
@@ -11,7 +11,7 @@ encrypting the root file system.
  Overview
 **********
 
-{Singularity} provides a feature to build and run encrypted
+{Project} provides a feature to build and run encrypted
 containers to allow users to encrypt the file system
 image within a SIF. This encryption can be performed using either a
 passphrase or asymmetrically via an RSA key pair in Privacy Enhanced
@@ -112,7 +112,7 @@ like so.
 PEM File Encryption
 ===================
 
-{Singularity} currently supports RSA encryption using a public/private
+{Project} currently supports RSA encryption using a public/private
 key-pair. Keys are supplied in PEM format. The public key is used to
 encrypt containers that can be decrypted on a host that has access to
 the secret private key.

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -7,12 +7,12 @@
 **********
 
 The ``remote`` command group allows users to manage the service
-endpoints {Singularity} will interact with for many common command
+endpoints {Project} will interact with for many common command
 flows. This includes managing credentials for image storage services
 and key servers used to locate public keys for SIF
 image verification. Currently, there are three main types of remote
 endpoints managed by this command group: the public Sylabs Cloud (or
-local {Singularity} Enterprise installation), OCI registries and
+local {Project} Enterprise installation), OCI registries and
 keyservers.
 
 *********************
@@ -24,7 +24,7 @@ Sylabs introduced the online `Sylabs Cloud
 <https://cloud.sylabs.io/keystore?sign=true>`_, and `Share
 <https://cloud.sylabs.io/library>`_ their container images with others.
 
-A fresh, default installation of {Singularity} is configured to connect
+A fresh, default installation of {Project} is configured to connect
 to the public `cloud.sylabs.io <https://cloud.sylabs.io>`__ services. If
 you only want to use the public services you just need to obtain an
 authentication token, and then ``singularity remote login``:
@@ -62,7 +62,7 @@ proxy environment variables to be set, or if a firewall is blocking
 access to ``*.sylabs.io``. Talk to your system administrator.
 
 You can interact with the public Sylabs Cloud using various
-{Singularity} commands:
+{Project} commands:
 
 `pull
 <cli/singularity_pull.html>`_,
@@ -180,7 +180,7 @@ To ``add`` a remote endpoint (for the current user only):
 
    $ singularity remote add <remote_name> <remote_uri>
 
-For example, if you have an installation of {Singularity} enterprise
+For example, if you have an installation of {Project} enterprise
 hosted at enterprise.example.com:
 
 .. code::
@@ -212,7 +212,7 @@ system) an administrative user should run:
 
    Global remote configurations can only be modified by the root user
    and are stored in the ``etc/singularity/remote.yaml`` file, at the
-   {Singularity} installation location.
+   {Project} installation location.
 
 Conversely, to ``remove`` an endpoint:
 
@@ -321,20 +321,20 @@ If you do not want to switch remote with ``remote use`` you can:
  Keyserver Configurations
 **************************
 
-By default, {Singularity} will use the keyserver correlated to the
+By default, {Project} will use the keyserver correlated to the
 active cloud service endpoint. This behavior can be changed or
 supplemented via the ``add-keyserver`` and ``remove-keyserver``
 commands. These commands allow an administrator to create a global list
 of key servers used to verify container signatures by default, where
 ``order 1`` is the first in the list. Other operations performed by
-{Singularity} that reach out to a keyserver will only use the first
+{Project} that reach out to a keyserver will only use the first
 entry, or ``order 1``, keyserver.
 
 When we list our default remotes, we can see that the default keyserver
 is ``https://keys.sylabs.io`` and the asterisk next to its order
 indicates that it is the keyserver associated to the current remote
 endpoint. We can also see the ``INSECURE`` column indicating that
-{Singularity} will use TLS when communicating with the keyserver.
+{Project} will use TLS when communicating with the keyserver.
 
 .. code::
 
@@ -401,7 +401,7 @@ Since we specified ``--order 1``, the ``https://pgp.example.com``
 keyserver was placed as the first entry in the list and the default
 keyserver was moved to second in the list. With the keyserver
 configuration above, all image default image verification performed by
-{Singularity} will first reach out to ``https://pgp.example.com`` and
+{Project} will first reach out to ``https://pgp.example.com`` and
 then to ``https://keys.sylabs.io`` when searching for public keys.
 
 If a keyserver requires authentication before usage, users can login
@@ -451,16 +451,16 @@ Now we can see that ``https://pgp.example.com`` is logged in:
  Managing OCI Registries
 *************************
 
-It is common for users of {Singularity} to use OCI registries as sources
+It is common for users of {Project} to use OCI registries as sources
 for their container images. Some registries require credentials to
 access certain images or the registry itself. Previously, the only
-methods in {Singularity} to supply credentials to registries were to
+methods in {Project} to supply credentials to registries were to
 supply credentials for each command or set environment variables for a
 single registry. See :ref:`Authentication via Interactive Login
 <sec:authentication_via_docker_login>` and :ref:`Authentication via
 Environment Variables <sec:authentication_via_environment_variables>`
 
-{Singularity} 3.7 introduces the ability for users to supply credentials
+{Project} 3.7 introduces the ability for users to supply credentials
 on a per registry basis with the ``remote`` command group.
 
 Users can login to an oci registry with the ``remote login`` command by
@@ -494,9 +494,9 @@ specifying a ``docker://`` prefix to the registry hostname:
    docker://docker.io  NO
 
 Now we can see that ``docker://docker.io`` shows up under
-``Authenticated Logins`` and {Singularity} will automatically supply the
+``Authenticated Logins`` and {Project} will automatically supply the
 configured credentials when interacting with DockerHub. We can also see
-the ``INSECURE`` column indicating that {Singularity} will use TLS when
+the ``INSECURE`` column indicating that {Project} will use TLS when
 communicating with the registry.
 
 We can login to multiple OCI registries at the same time:
@@ -529,7 +529,7 @@ We can login to multiple OCI registries at the same time:
    docker://docker.io             NO
    docker://registry.example.com  NO
 
-{Singularity} will supply the correct credentials for the registry based
+{Project} will supply the correct credentials for the registry based
 off of the hostname when using the following commands with a
 ``docker://`` or ``oras://`` URI:
 

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -16,9 +16,9 @@ When running containers you may need to set or override environment
 variables.
 
 The :ref:`metadata <sec:metadata>` of a container is information that
-describes the container. {Singularity} automatically records important
+describes the container. {Project} automatically records important
 information such as the definition file used to build a container. Other
-details such as the version of {Singularity} used are present as
+details such as the version of {Project} used are present as
 :ref:`labels <sec:labels>` on a container. You can also specify your own
 to be recorded against your container.
 
@@ -26,7 +26,7 @@ to be recorded against your container.
  Environment Overview
 **********************
 
-When you run a program in a container with {Singularity}, the
+When you run a program in a container with {Project}, the
 environment variables that the program sees are a combination of:
 
    -  The environment variables set in the base image (e.g. Docker
@@ -44,7 +44,7 @@ environment variables that the program sees are a combination of:
 
    -  The ``PATH`` variable can be manipulated to add entries.
 
-   -  Runtime variables ``SINGULARITY_xxx`` set by {Singularity} to
+   -  Runtime variables ``SINGULARITY_xxx`` set by {Project} to
       provide information about the container.
 
 The environment variables from the base image or definition file used to
@@ -65,7 +65,7 @@ environment section <build-environment>`.
  Environment from a base image
 *******************************
 
-When you build a container with {Singularity} you might *bootstrap* from
+When you build a container with {Project} you might *bootstrap* from
 a library or Docker image, or using Linux distribution bootstrap tools
 such as ``debootstrap``, ``yum`` etc.
 
@@ -119,7 +119,7 @@ The ``%runscript`` is set to echo the value.
 
 .. warning::
 
-   {Singularity} uses an embedded shell interpreter to evaluate and
+   {Project} uses an embedded shell interpreter to evaluate and
    setup container environments, therefore all commands executed from
    the ``%environment`` section have an execution timeout of **1 minute**.
    While it is possible to source a script from there, it
@@ -194,8 +194,8 @@ environment variables for correct operation of most software.
    LANG=C
    LD_LIBRARY_PATH=/.singularity.d/libs
    PATH=/startpath:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-   PROMPT_COMMAND=PS1="Singularity> "; unset PROMPT_COMMAND
-   PS1=Singularity>
+   PROMPT_COMMAND=PS1="{Project}> "; unset PROMPT_COMMAND
+   PS1={Project}>
    PWD=/home/dave/doc-tesrts
    SINGULARITY_COMMAND=exec
    SINGULARITY_CONTAINER=/home/dave/doc-tesrts/env.sif
@@ -213,12 +213,12 @@ environment variables for correct operation of most software.
    consider using ``--cleanenv``.
 
 ********************************************
- Environment from the {Singularity} runtime
+ Environment from the {Project} runtime
 ********************************************
 
 It can be useful for a program to know when it is running in a
-{Singularity} container, and some basic information about the container
-environment. {Singularity} will automatically set a number of
+{Project} container, and some basic information about the container
+environment. {Project} will automatically set a number of
 environment variables in a container that can be inspected by any
 program running in the container.
 
@@ -248,7 +248,7 @@ workflow.
 ``--env`` option
 ================
 
-*New in {Singularity} 3.6*
+*New in {Project} 3.6*
 
 The ``--env`` option on the ``run/exec/shell`` commands allows you to
 specify environment variables as ``NAME=VALUE`` pairs:
@@ -306,7 +306,7 @@ it finds ``myprog``.
 
 To ensure containers work correctly, when a host ``PATH`` might contain
 a lot of host-specific locations that are not present in the container,
-{Singularity} will ensure ``PATH`` in the container is set to a default.
+{Project} will ensure ``PATH`` in the container is set to a default.
 
 .. code::
 
@@ -357,12 +357,12 @@ Alternatively you could use the ``--env`` option to set a
 Escaping and evaluation of environment variables
 ================================================
 
-{Singularity} uses an embedded shell interpreter to process the
+{Project} uses an embedded shell interpreter to process the
 container startup scripts and environment. When this processing is
 performed, a single step of shell evaluation happens in the container
-context. The shell from which you are running {Singularity} may also
+context. The shell from which you are running {Project} may also
 evaluate variables on your command line before passing them to
-{Singularity}.
+{Project}.
 
 .. warning::
 
@@ -376,7 +376,7 @@ Using host variables
 To set a container environment variable to the value of a variable on
 the host, use double quotes around the variable, so that it is
 processed by the host shell before the value is passed to
-{Singularity}. For example:
+{Project}. For example:
 
 .. code::
 
@@ -429,7 +429,7 @@ This will result in ``LD_PRELOAD`` having the value
 ``/foo/bar/$LIB/baz.so`` inside the container.
 
 The host shell consumes the double ``\\``, and then environment
-processing within {Singularity} will consume the third ``\`` that
+processing within {Project} will consume the third ``\`` that
 escapes the literal ``$``.
 
 You can also use single quotes on the command line, to avoid one
@@ -443,17 +443,17 @@ level of escaping:
 Environment Variable Precedence
 ===============================
 
-When a container is run with {Singularity}, the container
+When a container is run with {Project}, the container
 environment is constructed in the following order:
 
    -  Clear the environment, keeping just ``HOME`` and
       ``SINGULARITY_APPNAME``.
    -  Set Docker/OCI defined environment variables, where a Docker or
       OCI image was used as the base for the container build.
-   -  If ``PATH`` is not defined set the {Singularity} default ``PATH``
+   -  If ``PATH`` is not defined set the {Project} default ``PATH``
       *or*
    -  If ``PATH`` is defined, add any missing path parts from
-      {Singularity} defaults
+      {Project} defaults
    -  Set environment variables defined explicitly in the
       ``%environment`` section of the definition file. These can
       override any previously set values, and may reference host
@@ -473,14 +473,14 @@ environment is constructed in the following order:
 
 .. warning::
 
-   While {Singularity} will process additional scripts found under
+   While {Project} will process additional scripts found under
    ``/.singularity.d/env`` inside the container, it is strongly
    recommended to avoid manipulating the container environment by
    directly adding or modifying scripts in this directory. Please use
    the ``%environment`` section of the definition file, and the
    ``$SINGULARITY_ENVIRONMENT`` file from ``%post`` if required.
 
-   A future version of {Singularity} may move container scripts,
+   A future version of {Project} may move container scripts,
    environment, and metadata outside of the container's root
    filesystem. This will permit further reproducibility and
    compatibility improvements, but will preclude environment
@@ -503,7 +503,7 @@ new files.
    A detailed description of what the ``umask`` is, and how it works can
    be found at `Wikipedia <https://en.wikipedia.org/wiki/Umask>`__.
 
-{Singularity} sets the ``umask`` in the container to match
+{Project} sets the ``umask`` in the container to match
 the value outside, unless:
 
    -  The ``--fakeroot`` option is used, in which case a ``0022`` umask
@@ -520,12 +520,12 @@ the value outside, unless:
  Container Metadata
 ********************
 
-Each {Singularity} container has metadata describing the container, how
+Each {Project} container has metadata describing the container, how
 it was built, etc. This metadata includes the definition file used to
 build the container and labels, which are specific pieces of information
 set automatically or explicitly when the container is built.
 
-{Singularity} container default labels are represented using the
+{Project} container default labels are represented using the
 `rc1 Label Schema <http://label-schema.org/rc1/>`_.
 
 .. _sec:labels:
@@ -540,7 +540,7 @@ container sets in its ``Dockerfile``, or a SIF container that sets
 labels in its definition file as described below.
 
 Inherited labels can only be overwritten during a build when the build
-is performed using the ``--force`` option. {Singularity} will warn that
+is performed using the ``--force`` option. {Project} will warn that
 it is not modifying an existing label when ``--force`` is not used:
 
 .. code::
@@ -552,7 +552,7 @@ it is not modifying an existing label when ``--force`` is not used:
 
 .. note::
 
-   {Singularity} 3.0 through 3.8 did not inherit labels from Docker/OCI
+   {Project} 3.0 through 3.8 did not inherit labels from Docker/OCI
    images during a build.
 
 Custom Labels
@@ -577,7 +577,7 @@ when you are writing the definition file, but can be obtained in the
 ``%post`` section of your definition file while the container is
 building.
 
-{Singularity} allows this, through adding labels to the
+{Project} allows this, through adding labels to the
 file defined by the ``SINGULARITY_LABELS`` environment variable in the
 ``%post`` section:
 
@@ -625,7 +625,7 @@ options will display any labels set on the container
    org.label-schema.usage.singularity.version: 3.7.0-rc.1
 
 We can easily see when the container was built, the source of the base
-image, and the exact version of {Singularity} that was used to build it.
+image, and the exact version of {Project} that was used to build it.
 
 The custom label ``OWNER`` that we set in our definition file is also
 visible.
@@ -838,7 +838,7 @@ environment files that are used when a container is executed.
 
 *You should not manually modify* files under ``/.singularity.d``, from
 your definition file during builds, or directly within your container
-image. {Singularity} replaces older action scripts
+image. {Project} replaces older action scripts
 dynamically, at runtime, to support new features. In the longer term,
 metadata will be moved outside of the container, and stored only in the
 SIF file metadata descriptor.
@@ -865,12 +865,12 @@ SIF file metadata descriptor.
    ├── libs
    ├── runscript
    ├── runscript.help
-   ├── Singularity
+   ├── {Project}
    └── startscript
 
 -  **actions**: This directory contains helper scripts to allow the
    container to carry out the action commands. (e.g. ``exec`` , ``run``
-   or ``shell``). In later versions of {Singularity}, these files may be
+   or ``shell``). In later versions of {Project}, these files may be
    dynamically written at runtime, *and should not be modified* in the
    container.
 
@@ -880,7 +880,7 @@ SIF file metadata descriptor.
    ``/.singularity.d/env/90-environment.sh``. Whenever possible, avoid
    modifying or creating environment files manually to prevent potential
    issues building & running containers with future versions of
-   {Singularity}. Additional
+   {Project}. Additional
    facilities such as ``--env`` and ``--env-file`` are available to
    allow manipulation of the container environment at runtime.
 
@@ -899,9 +899,9 @@ SIF file metadata descriptor.
 -  **runscript.help**: Contains the description that was added in the
    ``%help`` section.
 
--  **{Singularity}**: This is the definition file that was used to
+-  **{Project}**: This is the definition file that was used to
    generate the container. If more than 1 definition file was used to
-   generate the container additional {Singularity} files will appear in
+   generate the container additional {Project} files will appear in
    numeric order in a sub-directory called ``bootstrap_history``.
 
 -  **startscript**: The commands in this file will be executed when the

--- a/fakeroot.rst
+++ b/fakeroot.rst
@@ -86,7 +86,7 @@ the host network.
 
 .. warning::
 
-   For unprivileged installation of {Singularity} or if ``allow setuid =
+   For unprivileged installation of {Project} or if ``allow setuid =
    no`` is set in ``singularity.conf`` users won't be able to use a
    ``fakeroot`` network.
 
@@ -99,9 +99,9 @@ mappings in ``/etc/subgid``, so your username needs to be listed in
 those files with a valid mapping (see the admin-guide for details), if
 you can't edit the files ask an administrator.
 
-{Singularity} provides a ``singularity config fakeroot`` command 
+{Project} provides a ``singularity config fakeroot`` command 
 to allow configuration of the ``/etc/subuid`` and
-``/etc/subgid`` mappings from the {Singularity} command line. You must
+``/etc/subgid`` mappings from the {Project} command line. You must
 be a root user or run with ``sudo`` to use ``config fakeroot``, as the
 mapping files are security sensitive. See the admin-guide for more
 details.
@@ -129,7 +129,7 @@ Build
 With fakeroot an unprivileged user can now build an image from a
 definition file with few restrictions. Some bootstrap methods that
 require creation of block devices (like ``/dev/null``) may not always
-work correctly with **"fake root"**, {Singularity} uses seccomp filters
+work correctly with **"fake root"**, {Project} uses seccomp filters
 to give programs the illusion that block device creation succeeded. This
 appears to work with ``yum`` bootstraps and *may* work with other
 bootstrap methods, although ``debootstrap`` is known to not work.

--- a/gpu.rst
+++ b/gpu.rst
@@ -4,7 +4,7 @@
  GPU Support (NVIDIA CUDA & AMD ROCm)
 ######################################
 
-{Singularity} natively supports running application containers that use
+{Project} natively supports running application containers that use
 NVIDIA's CUDA GPU compute framework, or AMD's ROCm solution. This allows
 easy access to users of GPU-enabled machine learning frameworks such as
 tensorflow, regardless of the host operating system. As long as the host
@@ -15,7 +15,7 @@ older RHEL 7 host.
 Applications that support OpenCL for compute acceleration can also be
 used easily, with an additional bind option.
 
-{Singularity} experimental support is provided to use
+{Project} experimental support is provided to use
 Nvidia's ``nvidia-container-cli`` tooling for GPU container setup. This
 functionality, accessible via the new ``--nvccli`` flag, improves
 compatibility with OCI runtimes and exposes additional container
@@ -64,7 +64,7 @@ distributions may provide NVIDIA drivers and CUDA libraries, but they
 are often outdated which can lead to problems running applications
 compiled for the latest versions of CUDA.
 
-{Singularity} will find the NVIDIA/CUDA libraries on your host using the
+{Project} will find the NVIDIA/CUDA libraries on your host using the
 list of libraries in the configuration file
 ``etc/singularity/nvbliblist``, and resolving paths through the
 ``ldconfig`` cache. At time of release this list is appropriate for the
@@ -111,14 +111,14 @@ Then run the container with GPU support:
    You are running this container as user with ID 1000 and group 1000,
    which should map to the ID and group for your user on the Docker host. Great!
 
-   Singularity>
+   {Project}>
 
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
 
 .. code::
 
-   Singularity> python
+   {Project}> python
    Python 2.7.15+ (default, Jul  9 2019, 16:51:35)
    [GCC 7.4.0] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
@@ -140,7 +140,7 @@ tensorflow ``list_local_devices()`` function:
 Multiple GPUs
 =============
 
-By default, {Singularity} makes all host devices available in the
+By default, {Project} makes all host devices available in the
 container. When the ``--contain`` option is used a minimal ``/dev`` tree
 is created in the container, but the ``--nv`` option will ensure that
 all nvidia devices on the host are present in the container.
@@ -151,7 +151,7 @@ whether some or all host GPUs are visible inside a container. The
 ``nvidia-container-runtime`` explicitly binds the devices into the
 container dependent on the value of ``NVIDIA_VISIBLE_DEVICES``.
 
-To control which GPUs are used in a {Singularity} container that is run
+To control which GPUs are used in a {Project} container that is run
 with ``--nv`` you can set ``SINGULARITYENV_CUDA_VISIBLE_DEVICES`` before
 running the container, or ``CUDA_VISIBLE_DEVICES`` inside the container.
 This variable will limit the GPU devices that CUDA programs see.
@@ -173,7 +173,7 @@ Troubleshooting
 
 If the host installation of the NVIDIA / CUDA driver and libraries is
 working and up-to-date there are rarely issues running CUDA programs
-inside of {Singularity} containers. The most common issue seen is:
+inside of {Project} containers. The most common issue seen is:
 
 CUDA_ERROR_UNKNOWN when everything seems to be correctly configured
 -------------------------------------------------------------------
@@ -182,7 +182,7 @@ CUDA depends on multiple kernel modules being loaded. Not all of the
 modules are loaded at system startup. Some portions of the NVIDA driver
 stack are initialized when first needed. This is done using a setuid
 root binary, so initializing can be triggered by any user on the host.
-In {Singularity} containers, privilege escalation is blocked, so the
+In {Project} containers, privilege escalation is blocked, so the
 setuid root binary cannot initialize the driver stack fully.
 
 If you experience ``CUDA_ERROR_UNKNOWN`` in a container, initialize the
@@ -195,15 +195,15 @@ avoid driver unload.
 *******************************************
 
 The ``--nvccli`` option instructs
-{Singularity} to perform GPU container setup using the
+{Project} to perform GPU container setup using the
 ``nvidia-container-cli`` utility. This utility must be installed
-separately from {Singularity}. It is available in the repositories of
+separately from {Project}. It is available in the repositories of
 some distributions, and at:
 https://nvidia.github.io/libnvidia-container/
 
 .. warning::
 
-   This feature is considered experimental in {Singularity} as of now. It
+   This feature is considered experimental in {Project} as of now. It
    cannot not replace the legacy NVIDIA support in all situations, and
    should be tested carefully before use in production workflows.
 
@@ -227,7 +227,7 @@ Requirements & Limitations
    ``nvidia-container-cli`` is found on the search ``$PATH``.
 
 -  For security reasons, ``--nvccli`` cannot be used with
-   privileged mode in a set-uid install of {Singularity}.
+   privileged mode in a set-uid install of {Project}.
    Use the traditional binding method with ``--nv`` only or use
    ``--nvccli`` with the the ``--user`` (or ``-u``) option to run unprivileged.
    The option also cannot be used with ``--fakeroot``.
@@ -271,14 +271,14 @@ Then run the container with ``nvidia-container-cli`` GPU support:
    You are running this container as user with ID 1000 and group 1000,
    which should map to the ID and group for your user on the Docker host. Great!
 
-   Singularity>
+   {Project}>
 
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
 
 .. code::
 
-   Singularity> python
+   {Project}> python
    Python 2.7.15+ (default, Jul  9 2019, 16:51:35)
    [GCC 7.4.0] on linux2
    Type "help", "copyright", "credits" or "license" for more information.
@@ -299,7 +299,7 @@ tensorflow ``list_local_devices()`` function:
 GPU Selection
 =============
 
-When running with ``--nvccli``, by default {Singularity} will expose all
+When running with ``--nvccli``, by default {Project} will expose all
 GPUs on the host inside the container. This mirrors the functionality of
 the standard GPU support for the most common use-case.
 
@@ -352,7 +352,7 @@ devices, you can specify MIG identifiers / UUIDs.
 
    $ export NVIDIA_VISIBLE_DEVICES=MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/7/0
 
-{Singularity} does not configure MIG partitions. It is expected that
+{Project} does not configure MIG partitions. It is expected that
 these would be statically configured by the system administrator, or
 setup dynamically by a job scheduler / workflow system according to the
 requirements of the job.
@@ -360,14 +360,14 @@ requirements of the job.
 Other GPU Options
 =================
 
-In ``--nvccli`` mode, {Singularity} understands the following additional
+In ``--nvccli`` mode, {Project} understands the following additional
 environment variables. Note that these environment variables are read
-from the environment where ``singularity`` is run. {Singularity} does
+from the environment where ``singularity`` is run. {Project} does
 not currently read these settings from the container environment.
 
 -  ``NVIDIA_DRIVER_CAPABILITIES`` controls which libraries and utilities
    are mounted in the container, to support different requirements. The
-   default value under {Singularity} is ``compute,utility``, which will
+   default value under {Project} is ``compute,utility``, which will
    provide CUDA functionality and basic utilities such as
    ``nvidia-smi``. Other options include ``graphics`` for OpenGL/Vulkan
    support, ``video`` for the codecs SDK, and ``display`` to use X11
@@ -378,7 +378,7 @@ not currently read these settings from the container environment.
    container. Constraints can be set on ``cuda``, ``driver``, ``arch``,
    and ``brand`` values. Docker/OCI images may set these variables
    inside the container, to indicate runtime requirements. However,
-   these container variables are not yet interpreted by {Singularity}.
+   these container variables are not yet interpreted by {Project}.
 
 -  ``NVIDIA_DISABLE_REQUIRE`` will disable the enforcement of any
    ``NVIDIA_REQUIRE_*`` requirements that are set.
@@ -392,7 +392,7 @@ https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.htm
  AMD GPUs & ROCm
 *****************
 
-{Singularity} has a ``--rocm`` flag to support GPU compute with the
+{Project} has a ``--rocm`` flag to support GPU compute with the
 ROCm framework using AMD Radeon GPU cards.
 
 Commands that ``run``, or otherwise execute containers (``shell``,
@@ -430,7 +430,7 @@ you must ensure that:
 These requirements can be satisfied by following the requirements on the
 `ROCm web site <https://rocm.github.io/ROCmInstall.html>`__
 
-At time of release, {Singularity} was tested successfully on Debian 10
+At time of release, {Project} was tested successfully on Debian 10
 with ROCm 2.8/2.9 and the upstream kernel driver, and Ubuntu 18.04 with
 ROCm 2.9 and the DKMS driver.
 
@@ -468,7 +468,7 @@ tensorflow ``list_local_devices()`` function:
 
 .. code::
 
-   Singularity> ipython
+   {Project}> ipython
    Python 3.5.2 (default, Jul 10 2019, 11:58:48)
    Type 'copyright', 'credits' or 'license' for more information
    IPython 7.8.0 -- An enhanced Interactive Python. Type '?' for help.

--- a/index.rst
+++ b/index.rst
@@ -1,15 +1,15 @@
 ##########################
- {Singularity} User Guide
+ {Project} User Guide
 ##########################
 
-Welcome to the {Singularity} User Guide!
+Welcome to the {Project} User Guide!
 
-This guide aims to give an introduction to {Singularity}, brief
+This guide aims to give an introduction to {Project}, brief
 installation instructions, and cover topics relevant to users building
 and running containers.
 
 For a detailed guide to installation and configuration, please see the
-separate Admin Guide for this version of {Singularity} at
+separate Admin Guide for this version of {Project} at
 {admindocs}.
 
 ******************************************
@@ -19,9 +19,9 @@ separate Admin Guide for this version of {Singularity} at
 .. toctree::
    :maxdepth: 2
 
-   Introduction to {Singularity} <introduction>
+   Introduction to {Project} <introduction>
    Quick Start <quick_start>
-   Security in {Singularity} <security>
+   Security in {Project} <security>
 
 *********************
  Building Containers
@@ -44,7 +44,7 @@ non-root user.
  Container Signing & Encryption
 ********************************
 
-{Singularity} allows containers to be signed using a PGP key. The
+{Project} allows containers to be signed using a PGP key. The
 signature travels with the container image, allowing you to verify that
 the image is unmodified at any time. Encryption of containers using
 LUKS2 is also supported. Encrypted containers can be run without
@@ -72,7 +72,7 @@ decrypting them to disk first.
 ****************
 
 Once you've understood the basics, explore all the options which
-{Singularity} provides for accessing data, running persistent services
+{Project} provides for accessing data, running persistent services
 in containers, manipulating the container environment, and applying
 networking and security configuration.
 
@@ -92,9 +92,9 @@ networking and security configuration.
  Compatibility
 ***************
 
-{Singularity} has unique benefits and supports easy access to GPUs and
+{Project} has unique benefits and supports easy access to GPUs and
 other hardware. It also strives for compatibility with Docker/OCI
-container formats. Understand the differences between {Singularity} and
+container formats. Understand the differences between {Project} and
 Docker, as well as how to use containerized MPI and GPU applications.
 
 .. toctree::
@@ -102,14 +102,14 @@ Docker, as well as how to use containerized MPI and GPU applications.
 
    Support for Docker / OCI Containers <singularity_and_docker>
    OCI Runtime Support <oci_runtime>
-   Singularity and MPI applications <mpi>
+   {Project} and MPI applications <mpi>
    GPU Support <gpu>
 
 **************
  Get Involved
 **************
 
-We'd love you to get involved in the {Singularity} community! Whether
+We'd love you to get involved in the {Project} community! Whether
 through contributing feature and fixes, helping to answer questions from
 other users, or simply testing new releases.
 

--- a/introduction.rst
+++ b/introduction.rst
@@ -1,12 +1,12 @@
 .. _introduction:
 
 ###############################
- Introduction to {Singularity}
+ Introduction to {Project}
 ###############################
 
-{Singularity} is a *container* platform. It allows you to create and run
+{Project} is a *container* platform. It allows you to create and run
 containers that package up pieces of software in a way that is portable
-and reproducible. You can build a container using {Singularity} on your
+and reproducible. You can build a container using {Project} on your
 laptop, and then run it on many of the largest HPC clusters in the
 world, local university or company clusters, a single server, in the
 cloud, or on a workstation down the hall. Your container is a single
@@ -14,18 +14,18 @@ file, and you don't have to worry about how to install all the software
 you need on each different operating system.
 
 ************************
- Why use {Singularity}?
+ Why use {Project}?
 ************************
 
-{Singularity} was created to run complex applications on HPC clusters in
+{Project} was created to run complex applications on HPC clusters in
 a simple, portable, and reproducible way. First developed at Lawrence
 Berkeley National Laboratory, it quickly became popular at other HPC
-sites, academic sites, and beyond. {Singularity} is an open-source
+sites, academic sites, and beyond. {Project} is an open-source
 project, with a friendly community of developers and users. The user
-base continues to expand, with {Singularity} now used across industry
+base continues to expand, with {Project} now used across industry
 and academia in many areas of work.
 
-Many container platforms are available, but {Singularity} is focused on:
+Many container platforms are available, but {Project} is focused on:
 
    -  Verifiable reproducibility and security, using cryptographic
       signatures, an immutable container image format, and in-memory
@@ -64,7 +64,7 @@ Containers change the user space into a swappable component. This means
 that the entire user space portion of a Linux operating system,
 including programs, custom configurations, and environment can be
 independent of whether your system is running CentOS, Fedora etc.,
-underneath. A {Singularity} container packages up whatever you need into
+underneath. A {Project} container packages up whatever you need into
 a single, verifiable file.
 
 Software developers can now build their stack onto whatever operating
@@ -81,7 +81,7 @@ BYOE: Bring Your Own Environment!
 
 Engineering work-flows for research computing can be a complicated and
 iterative process, and even more so on a shared and somewhat inflexible
-production environment. {Singularity} solves this problem by making the
+production environment. {Project} solves this problem by making the
 environment flexible.
 
 Additionally, it is common (especially in education) for schools to
@@ -92,7 +92,7 @@ so they can immediately follow along.
 Reproducible science
 ====================
 
-{Singularity} containers can be built to include all of the programs,
+{Project} containers can be built to include all of the programs,
 libraries, data and scripts such that an entire demonstration can be
 contained and either archived or distributed for others to replicate no
 matter what version of Linux they are presently running.
@@ -102,12 +102,12 @@ Commercially supported code requiring a particular environment
 
 Some commercial applications are only certified to run on particular
 versions of Linux. If that application was installed into a
-{Singularity} container running the version of Linux that it is
+{Project} container running the version of Linux that it is
 certified for, that container could run on any Linux host. The
 application environment, libraries, and certified stack would all
 continue to run exactly as it is intended.
 
-Additionally, {Singularity} blurs the line between container and host
+Additionally, {Project} blurs the line between container and host
 such that your home directory (and other directories) exist within the
 container. Applications within the container have full and direct access
 to all files you own thus you can easily incorporate the contained
@@ -131,7 +131,7 @@ Similar to the above example, while this is less than ideal it is a fact
 of the research ecosystem. As an example, I know of one Linux
 distribution which has been end of life for 15 years which is still in
 production due to the software stack which is custom built for this
-environment. {Singularity} has no problem running that operating system
+environment. {Project} has no problem running that operating system
 and application stack on a current operating system and hardware.
 
 Complicated software stacks that are very host specific
@@ -146,7 +146,7 @@ prolong the use-fullness of the development effort considerably.
 Complicated work-flows that require custom installation and/or data
 ===================================================================
 
-Consolidating a work-flow into a {Singularity} container simplifies
+Consolidating a work-flow into a {Project} container simplifies
 distribution and replication of scientific results. Making containers
 available along with published work enables other scientists to build
 upon (and verify) previous scientific work.

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -6,7 +6,7 @@
 
 .. _sec:key_commands:
 
-{Singularity} has the ability to import, export and remove
+{Project} has the ability to import, export and remove
 PGP keys following the OpenPGP standard via `GnuPGP (GPG)
 <https://www.gnupg.org/gph/en/manual.html>`_. These commands only modify
 the local keyring and are not related to the cloud keystore.
@@ -17,7 +17,7 @@ the local keyring and are not related to the cloud keystore.
  Global keyring
 ******************************
 
-{Singularity} has a global keyring which can be managed by
+{Project} has a global keyring which can be managed by
 administrators with the ``--global`` option. This global keyring is
 used by ECL
 ({admindocs}/configfiles.html#ecl-toml)
@@ -28,7 +28,7 @@ verification.
  Key import command
 ********************
 
-{Singularity} allows you to import keys reading either from binary or
+{Project} allows you to import keys reading either from binary or
 armored key format and automatically detect if it is a private or public
 key and add it to the correspondent local keystore.
 

--- a/mpi.rst
+++ b/mpi.rst
@@ -1,7 +1,7 @@
 .. _mpi:
 
 ####################################
- {Singularity} and MPI applications
+ {Project} and MPI applications
 ####################################
 
 .. _sec-mpi:
@@ -12,11 +12,11 @@ communication across compute nodes of a single system or across compute
 platforms. There are two main open-source implementations of MPI at the
 moment - `OpenMPI <https://www.open-mpi.org/>`_ and `MPICH
 <https://www.mpich.org/>`_, both of which are supported by
-{Singularity}. The goal of this page is to demonstrate the development
-and running of MPI programs using {Singularity} containers.
+{Project}. The goal of this page is to demonstrate the development
+and running of MPI programs using {Project} containers.
 
 There are several ways of carrying this out, the most popular way of
-executing MPI applications installed in a {Singularity} container is to
+executing MPI applications installed in a {Project} container is to
 rely on the MPI implementation available on the host. This is called the
 *Host MPI* or the *Hybrid* model since both the MPI implementations
 provided by system administrators (on the host) and in the containers
@@ -39,20 +39,20 @@ host into the container.
 **************
 
 The basic idea behind the *Hybrid Approach* is when you execute a
-{Singularity} container with MPI code, you will call ``mpiexec`` or a
+{Project} container with MPI code, you will call ``mpiexec`` or a
 similar launcher on the ``singularity`` command itself. The MPI process
 outside of the container will then work in tandem with MPI inside the
 container and the containerized MPI code to instantiate the job.
 
-The Open MPI/{Singularity} workflow in detail:
+The Open MPI/{Project} workflow in detail:
 
 #. The MPI launcher (e.g., ``mpirun``, ``mpiexec``) is called by the
    resource manager or the user directly from a shell.
 #. Open MPI then calls the process management daemon (ORTED).
-#. The ORTED process launches the {Singularity} container requested by
+#. The ORTED process launches the {Project} container requested by
    the launcher command.
-#. {Singularity} instantiates the container and namespace environment.
-#. {Singularity} then launches the MPI application within the container.
+#. {Project} instantiates the container and namespace environment.
+#. {Project} then launches the MPI application within the container.
 #. The MPI application launches and loads the Open MPI libraries.
 #. The Open MPI libraries connect back to the ORTED process via the
    Process Management Interface (PMI).
@@ -80,7 +80,7 @@ installed on the host from source.
 Test Application
 ================
 
-To illustrate how {Singularity} can be used to execute MPI applications,
+To illustrate how {Project} can be used to execute MPI applications,
 we will assume for a moment that the application is ``mpitest.c``, a
 simple Hello World:
 
@@ -248,9 +248,9 @@ If the host MPI is Open MPI, the definition file looks like:
 Running an MPI Application
 ==========================
 
-The standard way to execute MPI applications with hybrid {Singularity}
+The standard way to execute MPI applications with hybrid {Project}
 containers is to run the native ``mpirun`` command from the host, which
-will start {Singularity} containers and ultimately MPI ranks within the
+will start {Project} containers and ultimately MPI ranks within the
 containers.
 
 Assuming your container with MPI and your application is already built,
@@ -262,7 +262,7 @@ container has been built based on the hybrid model:
    $ mpirun -n <NUMBER_OF_RANKS> singularity exec <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
 
 Practically, this command will first start a process instantiating
-``mpirun`` and then {Singularity} containers on compute nodes. Finally,
+``mpirun`` and then {Project} containers on compute nodes. Finally,
 when the containers start, the MPI binary is executed:
 
 .. code::
@@ -286,7 +286,7 @@ Approach* is to start the MPI application by calling the MPI launcher
 (e.g., `mpirun`) from the host. The main difference between the hybrid
 and bind approach is the fact that with the bind approach, the container
 usually does not include any MPI implementation. This means that
-{Singularity} needs to mount/bind the MPI available on the host into the
+{Project} needs to mount/bind the MPI available on the host into the
 container.
 
 Technically this requires two steps:
@@ -309,7 +309,7 @@ The drawbacks are:
    -  The user must ensure that the host MPI is compatible with the MPI
       used to compile and install the application in the container.
 
-The creation of a {Singularity} container for the bind model is based on
+The creation of a {Project} container for the bind model is based on
 the following steps:
 
 #. Compile your application on a system with the target MPI
@@ -400,7 +400,7 @@ to run the container in bind mode are:
 If your target system is setup with a batch system such as SLURM, a
 standard way to execute MPI applications is through a batch script. The
 following example illustrates the context of a batch script for Slurm
-that aims at starting a {Singularity} container on each node allocated
+that aims at starting a {Project} container on each node allocated
 to the execution of the job. It can easily be adapted for all major
 batch systems available.
 
@@ -432,7 +432,7 @@ A user can then submit a job by executing the following SLURM command:
 
 On many systems it is common to use an alternative launcher to start MPI
 applications, e.g. Slurm's ``srun`` rather than the ``mpirun`` provided
-by the MPI installation. This approach is supported with {Singularity}
+by the MPI installation. This approach is supported with {Project}
 as long as the container MPI version supports the same process
 management interface (e.g. PMI2 / PMIx) and version as is used by the
 launcher.
@@ -449,7 +449,7 @@ that MPI implementations are built to support them. You may need to
 install or bind Infiniband/Omnipath libraries into your containers when
 using these interconnects.
 
-By default {Singularity} exposes every device in ``/dev`` to the
+By default {Project} exposes every device in ``/dev`` to the
 container. If you run a container using the ``--contain`` or
 ``--containall`` flags a minimal ``/dev`` is used instead. You may need
 to bind in additional ``/dev/`` entries manually to support the
@@ -486,7 +486,7 @@ interconnect libraries may not be available or configured properly with
 the MPI stack in the container.
 
 Please check the following things carefully before asking questions in
-the {Singularity} community:
+the {Project} community:
 
    -  For the hybrid mode, is the MPI version on the host compatible
       with the version in the container? Newer MPI versions can
@@ -504,8 +504,8 @@ the {Singularity} community:
       container? Is the MPI stack in the container configured correctly
       to use them?
 
-We recommend using the {Singularity} Google Group or Slack Channel to
-ask for MPI advice from the {Singularity} community. HPC cluster
+We recommend using the {Project} Google Group or Slack Channel to
+ask for MPI advice from the {Project} community. HPC cluster
 configurations vary greatly and most MPI problems are related to MPI /
-interconnect configuration, and not caused by issues in {Singularity}
+interconnect configuration, and not caused by issues in {Project}
 itself.

--- a/networking.rst
+++ b/networking.rst
@@ -6,7 +6,7 @@
 
 .. _sec:networking:
 
-{Singularity} provides full integration with `cni
+{Project} provides full integration with `cni
 <https://github.com/containernetworking/cni>`_ , to make network
 virtualization easy. The following options can be used with the the
 action commands (``exec``, ``run``, and ``shell``) to create and
@@ -18,7 +18,7 @@ configure a virtualized network for a container.
    default. Unrestricted ability to configure networking for containers
    would allow users to affect networking on the host, or in a cluster.
 
-   {Singularity} allows the administrator to permit a list of
+   {Project} allows the administrator to permit a list of
    unprivileged users and/or groups to use specified network
    configurations. This is accomplished through settings in
    ``singularity.conf``. See the administrator guide for details.
@@ -61,7 +61,7 @@ hostname within the container.
 ***********
 
 Passing the ``--net`` flag will cause the container to join a new
-network namespace when it initiates. New in {Singularity} 3.0, a bridge
+network namespace when it initiates. New in {Project} 3.0, a bridge
 interface will also be set up by default.
 
 .. code::
@@ -95,7 +95,7 @@ When invoked, the ``--network`` option searches the singularity
 configuration directory (commonly
 ``/usr/local/etc/singularity/network/``) for the cni configuration file
 corresponding to the requested network type(s). Several configuration
-files are installed with {Singularity} by default corresponding to the
+files are installed with {Project} by default corresponding to the
 following network types:
 
    -  bridge
@@ -111,7 +111,7 @@ network with a loopback interface.
 Administrators can permit certain users or groups to request other
 network configurations through options in ``singularity.conf``.
 Additional cni configuration files can be added to the ``network``
-configuration directory as required, and {Singularity}'s provided
+configuration directory as required, and {Project}'s provided
 configurations may also be modified.
 
 ********************

--- a/oci_runtime.rst
+++ b/oci_runtime.rst
@@ -17,13 +17,13 @@ OCI is an acronym for the `Open Containers Initiative
 <https://www.opencontainers.org/>`_ - an independent organization whose
 mandate is to develop open standards relating to containerization. To
 date, standardization efforts have focused on container formats and
-runtimes. {Singularity}'s compliance with respect to the OCI Image
+runtimes. {Project}'s compliance with respect to the OCI Image
 Specification is considered in detail :ref:`elsewhere
-<sec:oci_overview>`. It is {Singularity}'s compliance with the OCI
+<sec:oci_overview>`. It is {Project}'s compliance with the OCI
 Runtime Specification that is of concern here.
 
 Briefly, compliance with respect to the OCI Runtime Specification is
-addressed in {Singularity} through the introduction of the ``oci``
+addressed in {Project} through the introduction of the ``oci``
 command group.
 
 .. note::
@@ -754,7 +754,7 @@ additional properties - for example:
       of the OCI runtime specification that the bundle is compliant with
 
    -  ``process`` - an optional property that specifies the container
-      process. When invoked via {Singularity}, sub-properties such as
+      process. When invoked via {Project}, sub-properties such as
       ``args`` are populated by making use of the contents of the
       ``.singularity.d`` directory, e.g. via ``$ sudo cat
       /var/tmp/busybox/config.json | jq [.process.args]``:
@@ -769,7 +769,7 @@ additional properties - for example:
 
    where ``run`` equates to the :ref:`familiar runscript
    <sec:inspect_container_metadata>` for this container. If image
-   creation is bootstrapped via a Docker or OCI agent, {Singularity}
+   creation is bootstrapped via a Docker or OCI agent, {Project}
    will make use of ``ENTRYPOINT`` or ``CMD`` (from the OCI image) to
    populate ``args``; for additional discussion, please refer to
    :ref:`Directing Execution <sec:def_files_execution>` in the section

--- a/persistent_overlays.rst
+++ b/persistent_overlays.rst
@@ -47,7 +47,7 @@ To use a persistent overlay, you must first have a container.
 File system image overlay
 =========================
 
-{Singularity} provides a command ``singularity overlay
+{Project} provides a command ``singularity overlay
 create`` to create persistent overlay images. You can create a single
 EXT3 overlay image or adding a EXT3 writable overlay partition to an
 existing SIF image.
@@ -115,16 +115,16 @@ The example below shows the directory overlay in action.
 
    $ sudo singularity shell --overlay my_overlay/ ubuntu.sif
 
-   {Singularity} ubuntu.sif:~> mkdir /data
+   {Project} ubuntu.sif:~> mkdir /data
 
-   {Singularity} ubuntu.sif:~> chown user /data
+   {Project} ubuntu.sif:~> chown user /data
 
-   {Singularity} ubuntu.sif:~> apt-get update && apt-get install -y vim
+   {Project} ubuntu.sif:~> apt-get update && apt-get install -y vim
 
-   {Singularity} ubuntu.sif:~> which vim
+   {Project} ubuntu.sif:~> which vim
    /usr/bin/vim
 
-   {Singularity} ubuntu.sif:~> exit
+   {Project} ubuntu.sif:~> exit
 
 .. _overlay-sif:
 
@@ -142,7 +142,7 @@ you must first create a file system image:
        mkfs.ext3 overlay.img
 
 Then, you can add the overlay to the SIF image using the ``sif``
-functionality of {Singularity}.
+functionality of {Project}.
 
 .. code::
 
@@ -182,13 +182,13 @@ were using a writable container.
 
    $ singularity shell --overlay my_overlay/ ubuntu.sif
 
-   {Singularity} ubuntu.sif:~> ls -lasd /data
+   {Project} ubuntu.sif:~> ls -lasd /data
    4 drwxr-xr-x 2 user root 4096 Apr  9 10:21 /data
 
-   {Singularity} ubuntu.sif:~> which vim
+   {Project} ubuntu.sif:~> which vim
    /usr/bin/vim
 
-   {Singularity} ubuntu.sif:~> exit
+   {Project} ubuntu.sif:~> exit
 
 If you mount your container without the ``--overlay`` directory, your
 changes will be gone.
@@ -197,12 +197,12 @@ changes will be gone.
 
    $ singularity shell ubuntu.sif
 
-   {Singularity} ubuntu.sif:~> ls /data
+   {Project} ubuntu.sif:~> ls /data
    ls: cannot access 'data': No such file or directory
 
-   {Singularity} ubuntu.sif:~> which vim
+   {Project} ubuntu.sif:~> which vim
 
-   {Singularity} ubuntu.sif:~> exit
+   {Project} ubuntu.sif:~> exit
 
 To resize an overlay, standard Linux tools which manipulate ext3 images
 can be used. For instance, to resize the 500MB file created above to

--- a/plugins.rst
+++ b/plugins.rst
@@ -8,12 +8,12 @@
  Overview
 **********
 
-A {Singularity} plugin is a package that can be dynamically loaded by
-the {Singularity} runtime, augmenting {Singularity} with experimental,
+A {Project} plugin is a package that can be dynamically loaded by
+the {Project} runtime, augmenting {Project} with experimental,
 non-standard and/or vendor-specific functionality. Currently, plugins
-are able to add commands and flags to {Singularity}. In the future,
+are able to add commands and flags to {Project}. In the future,
 plugins will also be able to interface with more complex subsystems of
-the {Singularity} runtime.
+the {Project} runtime.
 
 ***************
  Using Plugins
@@ -30,7 +30,7 @@ Plugins are packaged and distributed as binaries encoded with the
 versatile Singularity Image Format (SIF). However, plugin authors may
 also distribute the source code of their plugins. A plugin can be
 compiled from its source code with the ``compile`` command. A sample
-plugin ``test-plugin`` is included with the {Singularity} source code.
+plugin ``test-plugin`` is included with the {Project} source code.
 
 .. code::
 
@@ -46,20 +46,20 @@ the plugin's source code.
 
 .. note::
 
-   Currently, **all** plugins must be compiled from the {Singularity}
+   Currently, **all** plugins must be compiled from the {Project}
    source code tree.
 
-   Also, the plugins mechanism for the Go language that {Singularity} is
+   Also, the plugins mechanism for the Go language that {Project} is
    written in is quite restrictive - it requires extremely close version
    matching of packages used in a plugin to the ones used in the program
-   the plugin is built for. Additionally {Singularity} is using build
+   the plugin is built for. Additionally {Project} is using build
    time config to get the source tree location for ``singularity plugin
    compile`` so that you don't need to export environment variables etc,
    and there isn't mismatch between package path information that Go
    uses. This means that at present you must:
 
    -  Build plugins using the exact same version of the source code, in
-      the same location, as was used to build the {Singularity}
+      the same location, as was used to build the {Project}
       executable.
 
    -  Use the exact same version of Go that was used to build the
@@ -73,7 +73,7 @@ plugin, use the ``inspect`` command.
 
    $ singularity plugin inspect examples/plugins/test-plugin/test-plugin.sif
    Name: sylabs.io/test-plugin
-   Description: This is a short test plugin for {Singularity}
+   Description: This is a short test plugin for {Project}
    Author: Michael Bauer
    Version: 0.0.1
 
@@ -117,7 +117,7 @@ operation requires root privilege.
  Writing a Plugin
 ******************
 
-Developers interested in writing {Singularity} plugins can get started
+Developers interested in writing {Project} plugins can get started
 by reading the `Go documentation
 <https://godoc.org/github.com/sylabs/singularity/pkg/plugin>`_ for the
 plugin package. Furthermore, reading through the `source code

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -6,10 +6,10 @@
 
 .. _sec:quickstart:
 
-This guide is intended for running {Singularity} on a computer where you
-have root (administrative) privileges, and will install {Singularity}
+This guide is intended for running {Project} on a computer where you
+have root (administrative) privileges, and will install {Project}
 from source code. Other installation options, including building an RPM
-package and installing {Singularity} without root privileges are
+package and installing {Project} without root privileges are
 discussed in the `installation section of the admin guide
 <{admindocs}/installation.html>`__.
 
@@ -17,7 +17,7 @@ If you need to request an installation on your shared resource, see the
 :ref:`requesting an installation section <installation-request>` for
 information to send to your system administrator.
 
-For any additional help or support contact the Singularity Community:
+For any additional help or support contact the {Project} Community:
 https://apptainer.org/help
 
 .. _quick-installation:
@@ -26,8 +26,8 @@ https://apptainer.org/help
  Quick Installation Steps
 **************************
 
-You will need a Linux system to run {Singularity} natively. Options for
-using {Singularity} on Mac and Windows machines, along with alternate
+You will need a Linux system to run {Project} natively. Options for
+using {Project} on Mac and Windows machines, along with alternate
 Linux installation options are discussed in the `installation section of
 the admin guide
 <{admindocs}/installation.html>`__.
@@ -67,29 +67,29 @@ On CentOS/RHEL:
       cryptsetup \
       wget git
 
-There are 3 broad steps to installing {Singularity}:
+There are 3 broad steps to installing {Project}:
 
 #. :ref:`Installing Go <install>`
-#. :ref:`Downloading {Singularity} <download>`
-#. :ref:`Compiling {Singularity} Source Code <compile>`
+#. :ref:`Downloading {Project} <download>`
+#. :ref:`Compiling {Project} Source Code <compile>`
 
 .. _install:
 
 Install Go
 ==========
 
-{Singularity} is written in Go, and may require a newer version of Go than is
+{Project} is written in Go, and may require a newer version of Go than is
 available in the repositories of your distribution. We recommend installing the
 latest version of Go from the [official binaries](https://golang.org/dl/).
 
-{Singularity} aims to maintain support for the two most recent stable versions
+{Project} aims to maintain support for the two most recent stable versions
 of Go. This corresponds to the Go Release Maintenance Policy and Security
 Policy, ensuring critical bug fixes and security patches are available for all
 supported language versions.
 
 If you are building rpm or debian packages using the packaging supplied
 in the ``dist`` directory, and the operating system distribution of Go
-is below the minimum required by {Singularity}, the packages can make
+is below the minimum required by {Project}, the packages can make
 use of the native Go to compile a newer version of Go whose source
 tarball is included with the package source.  That capability is
 supplied so packages can be built on systems with no access to the
@@ -128,10 +128,10 @@ Set the Environment variable ``PATH`` to point to Go:
 
 .. _download:
 
-Download {Singularity} from a release
+Download {Project} from a release
 =====================================
 
-You can download {Singularity} from one of the releases. To see a full
+You can download {Project} from one of the releases. To see a full
 list, visit `the GitHub release page
 <https://github.com/apptainer/apptainer/releases>`_. After deciding on a
 release to install, you can run the following commands to proceed with
@@ -146,11 +146,11 @@ the installation.
 
 .. _compile:
 
-Compile the {Singularity} source code
+Compile the {Project} source code
 =====================================
 
-Now you are ready to build {Singularity}. Dependencies will be
-automatically downloaded. You can build {Singularity} using the
+Now you are ready to build {Project}. Dependencies will be
+automatically downloaded. You can build {Project} using the
 following commands:
 
 .. code::
@@ -159,19 +159,19 @@ following commands:
        make -C builddir && \
        sudo make -C builddir install
 
-{Singularity} must be installed as root to function properly.
+{Project} must be installed as root to function properly.
 
 *****************************************
- Overview of the {Singularity} Interface
+ Overview of the {Project} Interface
 *****************************************
 
-{Singularity}’s :ref:`command line interface <cli>` allows you to build
+{Project}’s :ref:`command line interface <cli>` allows you to build
 and interact with containers transparently. You can run programs inside
 a container as if they were running on your host system. You can easily
 redirect IO, use pipes, pass arguments, and access files, sockets, and
 ports on the host system from within a container.
 
-The ``help`` command gives an overview of {Singularity} options and
+The ``help`` command gives an overview of {Project} options and
 subcommands as follows:
 
 .. code::
@@ -185,10 +185,10 @@ subcommands as follows:
      singularity [global options...]
 
    Description:
-     {Singularity} containers provide an application virtualization layer enabling
+     {Project} containers provide an application virtualization layer enabling
      mobility of compute via both application and environment portability. With
-     {Singularity} one is capable of building a root file system that runs on any
-     other Linux system where {Singularity} is installed.
+     {Project} one is capable of building a root file system that runs on any
+     other Linux system where {Project} is installed.
 
    Options:
      -d, --debug     print debugging information (highest verbosity)
@@ -199,7 +199,7 @@ subcommands as follows:
      -v, --verbose   print additional information
 
    Available Commands:
-     build       Build a {Singularity} image
+     build       Build a {Project} image
      cache       Manage the local cache
      capability  Manage Linux capabilities for users and groups
      exec        Run a command within a container
@@ -220,7 +220,7 @@ subcommands as follows:
      sign        Attach a cryptographic signature to an image
      test        Run the user-defined tests within a container
      verify      Verify cryptographic signatures attached to an image
-     version     Show the version for {Singularity}
+     version     Show the version for {Project}
 
    Examples:
      $ singularity help <command> [<subcommand>]
@@ -266,26 +266,26 @@ command.
 
    For additional help or support, please visit https://www.sylabs.io/docs/
 
-{Singularity} uses positional syntax (i.e. the order of commands and
+{Project} uses positional syntax (i.e. the order of commands and
 options matters). Global options affecting the behavior of all commands
 follow the main ``singularity`` command. Then sub commands are followed
 by their options and arguments.
 
 For example, to pass the ``--debug`` option to the main ``singularity``
-command and run {Singularity} with debugging messages on:
+command and run {Project} with debugging messages on:
 
 .. code::
 
    $ singularity --debug run library://lolcow
 
 To pass the ``--containall`` option to the ``run`` command and run a
-{Singularity} image in an isolated manner:
+{Project} image in an isolated manner:
 
 .. code::
 
    $ singularity run --containall library://lolcow
 
-{Singularity} has the concept of command groups. For
+{Project} has the concept of command groups. For
 instance, to list Linux capabilities for a particular user, you would
 use the ``list`` command in the ``capability`` command group like so:
 
@@ -347,7 +347,7 @@ commands to download pre-built images from an external resource like the
 `Container Library <https://cloud.sylabs.io/library>`_ or `Docker Hub
 <https://hub.docker.com/>`_.
 
-When called on a native {Singularity} image like those provided on the
+When called on a native {Project} image like those provided on the
 Container Library, ``pull`` simply downloads the image file to your
 system.
 
@@ -358,7 +358,7 @@ system.
 You can also use ``pull`` with the ``docker://`` uri to reference Docker
 images served from a registry. In this case ``pull`` does not just
 download an image file. Docker images are stored in layers, so ``pull``
-must also combine those layers into a usable {Singularity} file.
+must also combine those layers into a usable {Project} file.
 
 .. code::
 
@@ -381,12 +381,12 @@ your container like so:
    $ singularity build lolcow.sif docker://sylabsio/lolcow
 
 Unlike ``pull``, ``build`` will convert your image to the latest
-{Singularity} image format after downloading it. ``build`` is like a
+{Project} image format after downloading it. ``build`` is like a
 “Swiss Army knife” for container creation. In addition to downloading
 images, you can use ``build`` to create images from other images or from
 scratch using a :ref:`definition file <definition-files>`. You can also
 use ``build`` to convert an image between the container formats
-supported by {Singularity}. To see a comparison of {Singularity}
+supported by {Project}. To see a comparison of {Project}
 definition file with Dockerfile, please see: :ref:`this section
 <sec:deffile-vs-dockerfile>`.
 
@@ -418,21 +418,21 @@ interact with it as though it were a small virtual machine.
 
    $ singularity shell lolcow_latest.sif
 
-   {Singularity} lolcow_latest.sif:~>
+   {Project} lolcow_latest.sif:~>
 
 The change in prompt indicates that you have entered the container
 (though you should not rely on that to determine whether you are in
 container or not).
 
-Once inside of a {Singularity} container, you are the same user as you
+Once inside of a {Project} container, you are the same user as you
 are on the host system.
 
 .. code::
 
-   {Singularity} lolcow_latest.sif:~> whoami
+   {Project} lolcow_latest.sif:~> whoami
    david
 
-   {Singularity} lolcow_latest.sif:~> id
+   {Project} lolcow_latest.sif:~> id
    uid=1000(david) gid=1000(david) groups=1000(david),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare)
 
 ``shell`` also works with the ``library://``, ``docker://``, and
@@ -485,7 +485,7 @@ command and disappears.
 Running a container
 ===================
 
-{Singularity} containers contain :ref:`runscripts <runscript>`. These
+{Project} containers contain :ref:`runscripts <runscript>`. These
 are user defined scripts that define the actions a container should
 perform when someone runs it. The runscript can be triggered with the
 `run
@@ -546,7 +546,7 @@ to run ``echo`` command in this shell:
 
    hello
 
-Because {Singularity} runscripts are evaluated shell scripts
+Because {Project} runscripts are evaluated shell scripts
 arguments can behave slightly differently than in Docker/OCI
 runtimes, if they contain shell code that may be evaluated. To
 replicate Docker/OCI behaviour you may need additional escaping or
@@ -581,7 +581,7 @@ Files on the host are reachable from within the container.
    Hello from inside the container
 
 This example works because ``hostfile.txt`` exists in the user’s home
-directory. By default {Singularity} bind mounts ``/home/$USER``,
+directory. By default {Project} bind mounts ``/home/$USER``,
 ``/tmp``, and ``$PWD`` into your container at runtime.
 
 You can specify additional directories to bind mount into your container
@@ -596,7 +596,7 @@ container.
    $ singularity exec --bind /data:/mnt lolcow_latest.sif cat /mnt/cow_advice.txt
    Drink milk (and never eat hamburgers).
 
-Pipes and redirects also work with {Singularity} commands just like they
+Pipes and redirects also work with {Project} commands just like they
 do with normal Linux commands.
 
 .. code::
@@ -619,7 +619,7 @@ do with normal Linux commands.
 
 .. _sec:buildimagesfromscratch:
 
-{Singularity} produces immutable images in the
+{Project} produces immutable images in the
 Singularity Image File (SIF) format. This ensures reproducible and
 verifiable images and allows for many extra benefits such as the ability
 to sign and verify your containers.
@@ -627,7 +627,7 @@ to sign and verify your containers.
 However, during testing and debugging you may want an image format that
 is writable. This way you can ``shell`` into the image and install
 software and dependencies until you are satisfied that your container
-will fulfill your needs. For these scenarios, {Singularity} also
+will fulfill your needs. For these scenarios, {Project} also
 supports the ``sandbox`` format (which is really just a directory).
 
 Sandbox Directories
@@ -641,11 +641,11 @@ To build into a ``sandbox`` (container in a directory) use the ``build
    $ sudo singularity build --sandbox ubuntu/ library://ubuntu
 
 This command creates a directory called ``ubuntu/`` with an entire
-Ubuntu Operating System and some {Singularity} metadata in your current
+Ubuntu Operating System and some {Project} metadata in your current
 working directory.
 
 You can use commands like ``shell``, ``exec`` , and ``run`` with this
-directory just as you would with a {Singularity} image. If you pass the
+directory just as you would with a {Project} image. If you pass the
 ``--writable`` option when you use your container you can also write
 files within the sandbox directory (provided you have the permissions to
 do so).
@@ -674,11 +674,11 @@ Doing so may break reproducibility if you have altered your sandbox
 outside of the context of a definition file, so you are advised to
 exercise care.
 
-{Singularity} Definition Files
+{Project} Definition Files
 ==============================
 
 For a reproducible, verifiable and production-quality container you
-should build a SIF file using a {Singularity} definition file. This also
+should build a SIF file using a {Project} definition file. This also
 makes it easy to add files, environment variables, and install custom
 software, and still start from your base of choice (e.g., the Container
 Library).
@@ -716,7 +716,7 @@ named lolcow.def), you would call build like so:
 
    $ sudo singularity build lolcow.sif lolcow.def
 
-In this example, the header tells {Singularity} to use a base Ubuntu
+In this example, the header tells {Project} to use a base Ubuntu
 16.04 image from the Container Library.
 
 -  The ``%post`` section executes within the container at build time
@@ -740,18 +740,18 @@ as Ubuntu, Debian, CentOS, Arch, and BusyBox. You can also use an
 existing container on your host system as a base.
 
 This quickstart document just scratches the surface of all of the things
-you can do with {Singularity}!
+you can do with {Project}!
 
 If you need additional help or support, see https://apptainer.org/help.
 
 .. _installation-request:
 
-{Singularity} on a shared resource
+{Project} on a shared resource
 ----------------------------------
 
 Perhaps you are a user who wants a few talking points and background to
 share with your administrator. Or maybe you are an administrator who
-needs to decide whether to install {Singularity}.
+needs to decide whether to install {Project}.
 
 This document, and the accompanying administrator documentation provides
 answers to many common questions.
@@ -763,11 +763,11 @@ similar to this:
 
    Dear shared resource administrator,
 
-   We are interested in having {Singularity} (https://apptainer.org)
-   installed on our shared resource. {Singularity} containers will allow us to
+   We are interested in having {Project} (https://apptainer.org)
+   installed on our shared resource. {Project} containers will allow us to
    build encapsulated environments, meaning that our work is reproducible and
    we are empowered to choose all dependencies including libraries, operating
-   system, and custom software. {Singularity} is already in use on many of the
+   system, and custom software. {Project} is already in use on many of the
    top HPC centers around the world. Examples include:
 
        Texas Advanced Computing Center
@@ -787,7 +787,7 @@ similar to this:
    Importantly, it has a vibrant team of developers, scientists, and HPC
    administrators that invest heavily in the security and development of the
    software, and are quick to respond to the needs of the community. To help
-   learn more about {Singularity}, I thought these items might be of interest:
+   learn more about {Project}, I thought these items might be of interest:
 
        - Security: A discussion of security concerns is discussed at
        {admindocs}/admin_quickstart.html

--- a/replacements.py
+++ b/replacements.py
@@ -12,15 +12,11 @@ def variableReplace(app, docname, source):
 # Add the needed variables to be replaced either on code or on text on the next
 # dictionary structure.
 variable_replacements = {
-    "{InstallationVersion}" : "3.8.5",
-    "{admindocs}" : "https://singularity.hpcng.org/admin-docs/3.8",
-    "{version}": "3.8",
-    "{adminversion}": "3.8",
-    # The 'Singularity' noun is now a replacement so we can have
-    # {Singularity}  rather than bare 'Singularity'... and HPCng can
-    # replace to SingularityPRO so that it is clearer where docs
-    # diverge a bit from Singularity<->SingularityPRO due to long-term backports etc.
-    "{Singularity}": "Singularity",
+    "{InstallationVersion}" : "1.0.0",
+    "{admindocs}" : "https://apptainer.org/docs/admin/main",
+    "{version}": "main",
+    "{adminversion}": "main",
+    "{Project}": "Apptainer",
 }
 
 

--- a/running_services.rst
+++ b/running_services.rst
@@ -5,13 +5,13 @@
 ##################
 
 There are :ref:`different ways <runcontainer>` in which you can run
-{Singularity} containers. If you use commands like ``run``, ``exec`` and
+{Project} containers. If you use commands like ``run``, ``exec`` and
 ``shell`` to interact with processes in the container, you are running
-{Singularity} containers in the foreground. {Singularity}, also lets you
+{Project} containers in the foreground. {Project}, also lets you
 run containers in a "detached" or "daemon" mode which can run different
 services in the background. A "service" is essentially a process running
 in the background that multiple different clients can use. For example,
-a web server or a database. To run services in a {Singularity} container
+a web server or a database. To run services in a {Project} container
 one should use *instances*. A container instance is a persistent and
 isolated version of the container image that runs in the background.
 
@@ -21,8 +21,8 @@ isolated version of the container image that runs in the background.
 
 .. _sec:instances:
 
-{Singularity} has the concept of *instances* allowing users
-to run services in {Singularity}. This page will help you understand
+{Project} has the concept of *instances* allowing users
+to run services in {Project}. This page will help you understand
 instances using an elementary example followed by a more useful example
 running an NGINX web server using instances. In the end, you will find a
 more detailed example of running an instance of an API that converts URL
@@ -43,11 +43,11 @@ also see the service start, and the web server running. But then if you
 were to exit the container, the process would continue to run within an
 unreachable mount namespace. The process would still be running, but you
 couldn't easily kill or interface with it. This is a called an orphan
-process. {Singularity} instances give you the ability to handle services
+process. {Project} instances give you the ability to handle services
 properly.
 
 **************************************
- Container Instances in {Singularity}
+ Container Instances in {Project}
 **************************************
 
 For demonstration, let's use an easy (though somewhat useless) example
@@ -70,7 +70,7 @@ To start an instance, you should follow this procedure :
 
    $ singularity instance start   alpine_latest.sif     instance1
 
-This command causes {Singularity} to create an isolated environment for
+This command causes {Project} to create an isolated environment for
 the container services to live inside. One can confirm that an instance
 is running by using the ``instance list`` command like so:
 
@@ -139,7 +139,7 @@ If you want to poke around inside of your instance, you can do a normal
 
    $ singularity shell instance://instance3
 
-   Singularity>
+   {Project}>
 
 When you are finished with your instance you can clean it up with the
 ``instance stop`` command as follows:
@@ -166,11 +166,11 @@ commands are all identical.
    ``\*`` to pass it properly.
 
 **************************************
- Nginx “Hello-world” in {Singularity}
+ Nginx “Hello-world” in {Project}
 **************************************
 
 The above example, although not very useful, should serve as a fair
-introduction to the concept of {Singularity} instances and running
+introduction to the concept of {Project} instances and running
 services in the background. The following illustrates a more useful
 example of setting up a sample NGINX web server using instances. First
 we will create a basic :ref:`definition file <definition-files>` (let's
@@ -186,7 +186,7 @@ call it nginx.def):
       nginx
 
 This downloads the official NGINX Docker container, converts it to a
-{Singularity} image, and tells it to run NGINX when you start the
+{Project} image, and tells it to run NGINX when you start the
 instance. Since we’re running a web server, we’re going to run the
 following commands as root.
 
@@ -203,7 +203,7 @@ following commands as root.
    execution, you should use ``--writable-tmpfs`` while starting the
    instance.
 
-Just like that we’ve downloaded, built, and run an NGINX {Singularity}
+Just like that we’ve downloaded, built, and run an NGINX {Project}
 image. And to confirm that it’s correctly running:
 
 .. code::
@@ -395,9 +395,9 @@ If you shell into the instance, you can see the running processes:
 .. code::
 
    $ sudo singularity shell instance://pdf
-   {Singularity}: Invoking an interactive shell within container...
+   {Project}: Invoking an interactive shell within container...
 
-   {Singularity} final.sif:/home/ysub> ps auxf
+   {Project} final.sif:/home/ysub> ps auxf
    USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
    root       461  0.0  0.0  18204  3188 pts/1    S    17:58   0:00 /bin/bash --norc
    root       468  0.0  0.0  36640  2880 pts/1    R+   17:59   0:00  \_ ps auxf
@@ -407,7 +407,7 @@ If you shell into the instance, you can see the running processes:
    root        27  0.0  0.5 1179476 40312 ?       Sl   15:10   0:00      \_ node /pdf_server/node_modules/.bin/nodemon --watch ./src -e js src/index.js
    root        39  0.0  0.7 936444 61220 ?        Sl   15:10   0:02          \_ /usr/local/bin/node src/index.js
 
-   {Singularity} final.sif:/home/ysub> exit
+   {Project} final.sif:/home/ysub> exit
 
 Making it Fancy
 ===============
@@ -428,10 +428,10 @@ apps.
    different task with it's own environment, metadata etc., without the
    need for a collection of different containers.
 
-   {Singularity} implements SCIF, and you can read more about how to use
+   {Project} implements SCIF, and you can read more about how to use
    it :ref:`apps <in the SCIF Apps section>`.
 
-   SCIF is not specific to {Singularity}. You can learn more about it at
+   SCIF is not specific to {Project}. You can learn more about it at
    the project site: <https://sci-f.github.io/>`_.
 
 First off, we’re going to move the installation of the url-to-pdf into

--- a/security.rst
+++ b/security.rst
@@ -1,22 +1,22 @@
 .. _security:
 
 ###########################
- Security in {Singularity}
+ Security in {Project}
 ###########################
 
 *****************
  Security Policy
 *****************
 
-If you suspect you have found a vulnerability in {Singularity} we want
+If you suspect you have found a vulnerability in {Project} we want
 to work with you so that it can be investigated, fixed, and disclosed in
 a responsible manner. Please follow the steps in our published `Security
 Policy <https://apptainer.org/security-policy/>`__, which begins with
 contacting us privately via security@apptainer.org
 
-We disclose vulnerabilities found in {Singularity} through public
+We disclose vulnerabilities found in {Project} through public
 CVE reports, and notifications on our community channels. We encourage
-all users to monitor new releases of {Singularity} for security
+all users to monitor new releases of {Project} for security
 information. Security patches are applied to the latest open-source
 release.
 
@@ -24,7 +24,7 @@ release.
  Background
 ************
 
-{Singularity} grew out of the need to implement a container platform
+{Project} grew out of the need to implement a container platform
 that was suitable for use on shared systems, such as HPC clusters. In
 these environments multiple people access a shared resource. User
 accounts, groups, and standard file permissions limit their access to
@@ -41,10 +41,10 @@ coordinating a daemon with other schedulers is difficult and, since the
 daemon is privileged, users can ask it to carry out actions that they
 wouldn't normally have permission to do.
 
-When a user runs a container with {Singularity}, it is started as a
+When a user runs a container with {Project}, it is started as a
 normal process running under the user's account. Standard file
 permissions and other security controls based on user accounts, groups,
-and processes apply. In a default installation {Singularity} uses a
+and processes apply. In a default installation {Project} uses a
 setuid starter binary to perform only the specific tasks needed to setup
 the container.
 
@@ -59,7 +59,7 @@ support for 'unprivileged user namespace creation'. This means a normal
 user can create a user namespace, in which most setup operations needed
 to run a container can be run, unprivileged.
 
-{Singularity} supports running containers without setuid, using user
+{Project} supports running containers without setuid, using user
 namespaces. It can be compiled with the ``--without-setuid`` option, or
 ``allow setuid = no`` can be set in ``singularity.conf`` to enable this.
 In this mode *all* operations run as the user who starts the
@@ -80,7 +80,7 @@ In this mode *all* operations run as the user who starts the
    and verification of the image's original signature cannot be
    performed.
 
--  Encryption is not supported. {Singularity} leverages kernel LUKS2
+-  Encryption is not supported. {Project} leverages kernel LUKS2
    mounts to run encrypted containers without decrypting their content
    to disk.
 
@@ -90,7 +90,7 @@ In this mode *all* operations run as the user who starts the
    reluctant to enable unprivileged user namespace creation.
 
 Because of the points above, the default mode of operation of
-{Singularity} uses a setuid binary. We aim to reduce the
+{Project} uses a setuid binary. We aim to reduce the
 circumstances that require this as new functionality is developed and
 reaches commonly deployed Linux distributions.
 
@@ -100,7 +100,7 @@ reaches commonly deployed Linux distributions.
 
 While other runtimes have aimed to safely sandbox containers executing
 as the ``root`` user, so that they cannot affect the host system,
-{Singularity} has adopted an alternative security model:
+{Project} has adopted an alternative security model:
 
 -  Containers should be run as an unprivileged user.
 
@@ -115,7 +115,7 @@ as the ``root`` user, so that they cannot affect the host system,
    The process ID space, network etc. are not isolated in separate
    namespaces by default.
 
-To accomplish this, {Singularity} uses a number of Linux kernel
+To accomplish this, {Project} uses a number of Linux kernel
 features. The container file system is mounted using the ``nosuid``
 option, and processes are started with the ``PR_NO_NEW_PRIVS`` flag set.
 This means that even if you run ``sudo`` inside your container, you
@@ -123,14 +123,14 @@ won't be able to change to another user, or gain root privileges by
 other means.
 
 If you do require the additional isolation of the network, devices, PIDs
-etc. provided by other runtimes, {Singularity} can make use of
+etc. provided by other runtimes, {Project} can make use of
 additional namespaces and functionality such as seccomp and cgroups.
 
 ********************************
  Singularity Image Format (SIF)
 ********************************
 
-{Singularity} uses SIF as its default container format. A SIF container
+{Project} uses SIF as its default container format. A SIF container
 is a single file, which makes it easy to manage and distribute. Inside
 the SIF file, the container filesystem is held in a SquashFS object. By
 default, we mount the container filesystem directly using SquashFS. On a
@@ -151,12 +151,12 @@ easier to share and obtain public keys for container verification.
 
 A container may be signed once, by a trusted individual who approves its
 use. It could also be signed with multiple keys to signify it has passed
-each step in a CI/CD QA & Security process. {Singularity} can be
+each step in a CI/CD QA & Security process. {Project} can be
 configured with an execution control list (ECL), which requires the
 presence of one or more valid signatures, to limit execution to approved
 containers.
 
-In {Singularity} 3.4 and above, the root filesystem of a container
+In {Project} 3.4 and above, the root filesystem of a container
 (stored in the squashFS partition of SIF) can be encrypted. As a result,
 everything inside the container becomes inaccessible without the correct
 key or passphrase. The content of the container is private, even if the
@@ -172,7 +172,7 @@ decrypted to disk in order to run it.
  Configuration & Runtime Options
 *********************************
 
-System administrators who manage {Singularity} can use configuration
+System administrators who manage {Project} can use configuration
 files to set security restrictions, grant or revoke a user’s
 capabilities, manage resources and authorize containers etc.
 
@@ -184,6 +184,6 @@ Configuration files and their parameters are documented for
 administrators documented `here
 <{admindocs}/configfiles.html>`__.
 
-When running a container as root, Singularity can apply hardening rules
+When running a container as root, {Project} can apply hardening rules
 using cgroups, seccomp, apparmor. See :ref:`details of these options
 here <security-options>`.

--- a/security_options.rst
+++ b/security_options.rst
@@ -6,10 +6,10 @@
 
 .. _sec:security_options:
 
-{Singularity} implements security related options in the
+{Project} implements security related options in the
 container runtime. This document describes the methods users
 have for specifying the security scope and context when running
-{Singularity} containers.
+{Project} containers.
 
 ********************
  Linux Capabilities
@@ -29,7 +29,7 @@ have for specifying the security scope and context when running
    a user special privileges within a container. For that and similar
    use cases, the :ref:`fakeroot feature <fakeroot>` is a better option.
 
-{Singularity} provides full support for granting and revoking Linux
+{Project} provides full support for granting and revoking Linux
 capabilities on a user or group basis. For example, let us suppose that
 an admin has decided to grant a user (named ``pinger``) capabilities to
 open raw sockets so that they can use ``ping`` in a container where the
@@ -53,7 +53,7 @@ also request the capability when executing a container with the
    rtt min/avg/max/mdev = 73.178/73.178/73.178/0.000 ms
 
 If the admin decides that it is no longer necessary to allow the user
-``pinger`` to open raw sockets within {Singularity} containers, they can
+``pinger`` to open raw sockets within {Project} containers, they can
 revoke the appropriate Linux capability and ``pinger`` will not be able
 to add that capability to their containers anymore:
 
@@ -66,7 +66,7 @@ to add that capability to their containers anymore:
 Another scenario which is atypical of shared resource environments, but
 useful in cloud-native architectures is dropping capabilities when
 spawning containers as the root user to help minimize attack surfaces.
-With a default installation of {Singularity}, containers created by the
+With a default installation of {Project}, containers created by the
 root user will maintain all capabilities. This behavior is configurable
 if desired. Check out the `capability configuration
 <{admindocs}/configfiles.html#capability.json>`_
@@ -106,7 +106,7 @@ this keyword.
  Building encrypted containers
 *******************************
 
-Beginning in {Singularity} 3.4.0 it is possible to build and run
+Beginning in {Project} 3.4.0 it is possible to build and run
 encrypted containers. The containers are decrypted at runtime entirely
 in kernel space, meaning that no intermediate decrypted data is ever
 present on disk. See :ref:`encrypted containers <encryption>` for more
@@ -116,7 +116,7 @@ details.
  Security related action options
 *********************************
 
-{Singularity} has many security related flags that can be passed to the
+{Project} has many security related flags that can be passed to the
 action commands; ``shell``, ``exec``, and ``run`` allowing fine grained
 control of security.
 
@@ -137,9 +137,9 @@ binary. The most well-known SetUID binaries are owned by root and allow
 a user to execute a command with elevated privileges. But other SetUID
 binaries may allow a user to execute a command as a service account.
 
-By default SetUID is disallowed within {Singularity} containers as a
+By default SetUID is disallowed within {Project} containers as a
 security precaution. But the root user can override this precaution and
-allow SetUID binaries to behave as expected within a {Singularity}
+allow SetUID binaries to behave as expected within a {Project}
 container with the ``--allow-setuid`` option like so:
 
 .. code::
@@ -190,7 +190,7 @@ container.
 ==============
 
 The ``--security`` flag allows the root user to leverage security
-modules such as SELinux, AppArmor, and seccomp within your {Singularity}
+modules such as SELinux, AppArmor, and seccomp within your {Project}
 container. You can also change the UID and GID of the user within the
 container at runtime.
 
@@ -207,11 +207,11 @@ For instance:
 To use seccomp to blacklist a command follow this procedure. (It is
 actually preferable from a security standpoint to whitelist commands but
 this will suffice for a simple example.) Note that this example was run
-on Ubuntu and that {Singularity} was installed with the
+on Ubuntu and that {Project} was installed with the
 ``libseccomp-dev`` and ``pkg-config`` packages as dependencies.
 
 First write a configuration file. An example configuration file is
-installed with {Singularity}, normally at
+installed with {Project}, normally at
 ``/usr/local/etc/singularity/seccomp-profiles/default.json``. For this
 example, we will use a much simpler configuration file to blacklist the
 ``mkdir`` command.
@@ -250,7 +250,7 @@ the container like so:
 
    $ sudo singularity shell --security seccomp:/home/david/no_mkdir.json my_container.sif
 
-   Singularity> mkdir /tmp/foo
+   {Project}> mkdir /tmp/foo
    Bad system call (core dumped)
 
 Note that attempting to use the blacklisted ``mkdir`` command resulted

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -6,9 +6,9 @@
 
 .. _sec:signnverify:
 
-{Singularity} has the ability to create and manage PGP keys
+{Project} has the ability to create and manage PGP keys
 and use them to sign and verify containers. This provides a trusted
-method for {Singularity} users to share containers. It ensures a
+method for {Project} users to share containers. It ensures a
 bit-for-bit reproduction of the original container as the author
 intended it.
 
@@ -72,7 +72,7 @@ Generating and managing PGP keys
 To sign your own containers you first need to generate one or more keys.
 
 If you attempt to sign a container before you have generated any keys,
-{Singularity} will guide you through the interactive process of creating
+{Project} will guide you through the interactive process of creating
 a new key. Or you can use the ``newpair`` subcommand in the ``key``
 command group like so:.
 
@@ -153,7 +153,7 @@ signing).
 Searching for keys
 ==================
 
-{Singularity} allows you to search the keystore for public keys. You can
+{Project} allows you to search the keystore for public keys. You can
 search for names, emails, and fingerprints (key IDs). When searching for
 a fingerprint, you need to use ``0x`` before the fingerprint, check the
 example:

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -6,15 +6,15 @@
 
 The Open Containers Initiative (OCI) container format, which grew out of
 Docker, is the dominant standard for cloud-focused containerized
-deployments of software. Although {Singularity}'s own container format
+deployments of software. Although {Project}'s own container format
 has many unique advantages, it's likely you will need to work with
 Docker/OCI containers at some point.
 
-{Singularity} aims for maximum compatibility with Docker, within the
+{Project} aims for maximum compatibility with Docker, within the
 constraints on a runtime that is well suited for use on shared systems
 and especially in HPC environments.
 
-Using {Singularity} you can:
+Using {Project} you can:
 
 -  Pull, run, and build from most containers on Docker Hub, without
    changes.
@@ -25,7 +25,7 @@ Using {Singularity} you can:
 
 This section will highlight these workflows, and discuss the limitations
 and best practices to keep in mind when creating containers targeting
-both Docker and {Singularity}.
+both Docker and {Project}.
 
 ****************************
  Containers From Docker Hub
@@ -38,7 +38,7 @@ or build from containers that are hosted there.
 Public Containers
 =================
 
-It's easy to run a public Docker Hub container with {Singularity}. Just
+It's easy to run a public Docker Hub container with {Project}. Just
 put ``docker://`` in front of the container repository and tag. To run
 the container that's called ``sylabsio/lolcow:latest``:
 
@@ -65,10 +65,10 @@ the container that's called ``sylabsio/lolcow:latest``:
                    ||----w |
                    ||     ||
 
-Note that {Singularity} retrieves blobs and configuration data from
+Note that {Project} retrieves blobs and configuration data from
 Docker Hub, extracts the layers that make up the Docker container, and
 creates a SIF file from them. This SIF file is kept in your
-{Singularity} :ref:`cache directory <sec:cache>`, so if you run the same
+{Project} :ref:`cache directory <sec:cache>`, so if you run the same
 Docker container again the downloads and conversion aren't required.
 
 To obtain the Docker container as a SIF file in a specific location,
@@ -101,7 +101,7 @@ Docker Hub Limits
 
 Docker Hub introduced limits on anonymous access to its API in November
 2020. Every time you use a ``docker://`` URI to run, pull etc. a
-container {Singularity} will make requests to Docker Hub in order to
+container {Project} will make requests to Docker Hub in order to
 check whether the container has been modified there. On shared systems,
 and when running containers in parallel, this can quickly exhaust the
 Docker Hub API limits.
@@ -118,9 +118,9 @@ Authentication / Private Containers
 
 To make use of the API limits under a Docker Hub account, or to access
 private containers, you'll need to authenticate to Docker Hub. There are
-a number of ways to do this with {Singularity}.
+a number of ways to do this with {Project}.
 
-Singularity CLI Remote Command
+{Project} CLI Remote Command
 ------------------------------
 
 The ``singularity remote login`` command supports logging into Docker
@@ -154,13 +154,13 @@ Docker CLI Authentication
 
 If you have the ``docker`` CLI installed on your machine, you can
 ``docker login`` to your account. This stores authentication information
-in ``~/.docker/config.json``. The process that {Singularity} uses to
+in ``~/.docker/config.json``. The process that {Project} uses to
 retrieve Docker / OCI containers will attempt to use this information to
 login.
 
 .. note::
 
-   {Singularity} can only read credentials stored directly in
+   {Project} can only read credentials stored directly in
    ``~/.docker/config.json``. It cannot read credentials from external
    Docker credential helpers.
 
@@ -179,12 +179,12 @@ credentials, use the ``--docker-login`` flag:
 Environment Variables
 ---------------------
 
-When calling {Singularity} in a CI/CD workflow, or other non-interactive
+When calling {Project} in a CI/CD workflow, or other non-interactive
 scenario, it may be useful to specify Docker Hub login credentials using
 environment variables. These are often the default way of passing
 secrets into jobs within CI pipelines.
 
-Singularity accepts a username, and password / token, as
+{Project} accepts a username, and password / token, as
 ``SINGULARITY_DOCKER_USERNAME`` and ``SINGULARITY_DOCKER_PASSWORD``
 respectively. These environment variables will override any stored
 credentials.
@@ -199,7 +199,7 @@ credentials.
  Containers From Other Registries
 **********************************
 
-You can use ``docker://`` URIs with {Singularity} to pull and run
+You can use ``docker://`` URIs with {Project} to pull and run
 containers from OCI registries other than Docker Hub. To do this, you'll
 need to include the hostname or IP address of the registry in your
 ``docker://`` URI. Authentication with other registries is carried out
@@ -233,10 +233,10 @@ just include the ``quay.io`` hostname in your ``docker://`` URI:
 
 To pull containers from private repositories you will need to generate a
 CLI token in the Quay web interface, then use it to login with
-{Singularity}. Use the same methods as described for Docker Hub above:
+{Project}. Use the same methods as described for Docker Hub above:
 
 -  Run ``singularity remote login --username myuser docker://quay.io``
-   to store your credentials for {Singularity}.
+   to store your credentials for {Project}.
 -  Use ``docker login quay.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
 -  Set the ``SINGULARITY_DOCKER_USERNAME`` and
@@ -247,7 +247,7 @@ NVIDIA NGC
 
 The NVIDIA NGC catalog at https://ngc.nvidia.com contains various GPU
 software, packaged in containers. Many of these containers are
-specifically documented by NVIDIA as supported by {Singularity}, with
+specifically documented by NVIDIA as supported by {Project}, with
 instructions available.
 
 Previously, an account and API token was required to pull NGC
@@ -269,7 +269,7 @@ Docker Hub), with the username ``$oauthtoken`` and the password set to
 your NGC API key.
 
 -  Run ``singularity remote login --username \$oauthtoken
-   docker://nvcr.io`` to store your credentials for {Singularity}.
+   docker://nvcr.io`` to store your credentials for {Project}.
 -  Use ``docker login nvcr.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
 -  Set the ``SINGULARITY_DOCKER_USERNAME="\$oauthtoken"`` and
@@ -301,7 +301,7 @@ Use one of the following authentication methods (detailed above for
 Docker Hub), with your username and personal access token:
 
 -  Run ``singularity remote login --username myuser docker://ghcr.io``
-   to store your credentials for {Singularity}.
+   to store your credentials for {Project}.
 -  Use ``docker login ghcr.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
 -  Set the ``SINGULARITY_DOCKER_USERNAME`` and
@@ -318,7 +318,7 @@ in order to obtain a username and password.
 
 .. warning::
 
-   The ECR Docker credential helper cannot be used, as {Singularity}
+   The ECR Docker credential helper cannot be used, as {Project}
    does not currently support external credential helpers used with
    Docker, only reading credentials stored directly in the
    ``.docker/config.json`` file.
@@ -336,7 +336,7 @@ Then login using one of the following methods:
 
 -  Run ``singularity remote login --username AWS
    docker://<accountid>.dkr.ecr.<region>.amazonaws.com`` to store your
-   credentials for {Singularity}.
+   credentials for {Project}.
 
 -  Use ``docker login --username AWS
    <accountid>.dkr.ecr.<region>.amazonaws.com`` if ``docker`` is on your
@@ -362,14 +362,14 @@ for more information on these options.
 
 Generally, for identities, using ``az acr login`` from the Azure CLI
 will add credentials to ``.docker/config.json`` which can be read by
-{Singularity}.
+{Project}.
 
 Service Principle accounts will have an explicit username and password,
 and you should authenticate using one of the following methods:
 
 -  Run ``singularity remote login --username myuser
    docker://myregistry.azurecr.io`` to store your credentials for
-   {Singularity}.
+   {Project}.
 
 -  Use ``docker login --username myuser myregistry.azurecr.io`` if
    ``docker`` is on your machine.
@@ -392,11 +392,11 @@ methods.
 
 If you wish to use an existing Docker or OCI container as the basis for
 a new container, you will need to specify it as the *bootstrap* source
-in a {Singularity} definition file.
+in a {Project} definition file.
 
 Just as you can run or pull containers from different registries using a
 ``docker://`` URI, you can use different headers in a definition file to
-instruct {Singularity} where to find the container you want to use as
+instruct {Project} where to find the container you want to use as
 the starting point for your build.
 
 Registries In Definition Files
@@ -420,7 +420,7 @@ tag:
    From: ubuntu:20.04
 
 If you ``singularity build`` a definition file with these lines,
-{Singularity} will fetch the ``ubuntu:20.04`` container image from
+{Project} will fetch the ``ubuntu:20.04`` container image from
 Docker Hub, and extract it as the basis for your new container.
 
 Other Registries
@@ -446,7 +446,7 @@ Authentication During a Build
 
 If you are building from an image in a private registry you will need to
 ensure that the credentials needed to access the image are available to
-{Singularity}.
+{Project}.
 
 A build might be run as the ``root`` user, e.g. via ``sudo``, or under
 your own account with ``--fakeroot``.
@@ -457,7 +457,7 @@ stored credentials or environment variables must be available to the
 
 -  Use the ``--docker-login`` flag for a one-time interactive login.
    I.E. run ``sudo singularity build --docker-login myimage.sif
-   Singularity``.
+   {Project}``.
 
 -  Set the ``SINGULARITY_DOCKER_USERNAME`` and
    ``SINGULARITY_DOCKER_PASSWORD`` environment variables. Pass the
@@ -479,7 +479,7 @@ Archives & Docker Daemon
 
 As well as being hosted in a registry, Docker / OCI containers might be
 found inside a running Docker daemon, or saved as an archive.
-{Singularity} can build from these locations by using specialized
+{Project} can build from these locations by using specialized
 bootstrap agents.
 
 Containers Cached by the Docker Daemon
@@ -532,7 +532,7 @@ registry, the ``docker-daemon`` bootstrap agent will not try to pull a
 
    In the example above, the build was performed without ``sudo``. This
    is possible only when the user is part of the ``docker`` group on the
-   host, since {Singularity} must contact the Docker daemon through its
+   host, since {Project} must contact the Docker daemon through its
    socket. If you are not part of the ``docker`` group you will need to
    use ``sudo`` for the build to complete successfully.
 
@@ -549,7 +549,7 @@ Containers in Docker Archive Files
 
 Docker allows containers to be exported into single file tar archives.
 These cannot be run directly, but are intended to be imported into
-Docker to run at a later date, or another location. {Singularity} can
+Docker to run at a later date, or another location. {Project} can
 build from (or run) these archive files, by extracting them as part of
 the build process.
 
@@ -622,8 +622,8 @@ filename in the ``From:`` line:
  Differences and Limitations vs Docker
 ***************************************
 
-Though Docker / OCI container compatibility is a goal of {Singularity},
-there are some differences and limitations due to the way {Singularity}
+Though Docker / OCI container compatibility is a goal of {Project},
+there are some differences and limitations due to the way {Project}
 was designed to work well on shared systems and HPC clusters. If you are
 having difficulty running a specific Docker container, check through the
 list of differences below. There are workarounds for many of the issues
@@ -632,7 +632,7 @@ that you are most likely to face.
 Read-only by Default
 ====================
 
-{Singularity}'s container image format (SIF) is generally read-only.
+{Project}'s container image format (SIF) is generally read-only.
 This permits containers to be run in parallel from a shared location on
 a network filesystem, support in-built signing and verification, and
 offer encryption. A container's filesystem is mounted directly from the
@@ -642,7 +642,7 @@ When a container is run using Docker its layers are extracted, and the
 resulting container filesystem can be written to and modified by
 default. If a Docker container expects to write files, you will need to
 follow one of the following methods to allow it to run under
-{Singularity}.
+{Project}.
 
 -  A directory from the host can be passed into the container with the
    ``--bind`` or ``--mount`` flags. It needs to be mounted inside the
@@ -670,7 +670,7 @@ use, and the filesystem support, some type of locking in order that the
 parallel runs do not interfere.
 
 A writable overlay file in a SIF partition cannot be used in parallel.
-{Singularity} will refuse to run concurrently using the same SIF
+{Project} will refuse to run concurrently using the same SIF
 writable overlay partition.
 
 Dockerfile ``USER``
@@ -680,17 +680,17 @@ The ``Dockerfile`` used to build a Docker container may contain a
 ``USER`` statement. This tells the container runtime that it should run
 the container under the specified user account.
 
-Because {Singularity} is designed to provide easy and safe access to
+Because {Project} is designed to provide easy and safe access to
 data on the host system, work under batch schedulers, etc., it does not
 permit changing the user account the container is run as.
 
 Any ``USER`` statement in a ``Dockerfile`` will be ignored by
-{Singularity} when the container is run. In practice, this often does
+{Project} when the container is run. In practice, this often does
 not affect the execution of the software in the container. Software that
 is written in a way that requires execution under a specific user
-account will generally require modification for use with {Singularity}.
+account will generally require modification for use with {Project}.
 
-{Singularity}'s ``--fakeroot`` mode will start a container as a fake
+{Project}'s ``--fakeroot`` mode will start a container as a fake
 ``root`` user, mapped to the user's real account outside of the
 container. Inside the container it is possible to change to another user
 account, which is mapped to a configured range of sub-uids / gids
@@ -701,7 +701,7 @@ if your adminstrator has configured the system for ``--fakeroot``.
 Default Mounts / $HOME
 ======================
 
-A default installation of {Singularity} will mount the user's home
+A default installation of {Project} will mount the user's home
 directory, ``/tmp`` directory, and the current working directory, into
 each container that is run. Administrators may also configure e.g. HPC
 project directories to automatically bind mount. Docker does not mount
@@ -715,7 +715,7 @@ installed packages for Python into your home directory (``pip install
 can cause conflicts and unexpected behavior.
 
 If you experience issues, use the ``--contain`` option to stop
-{Singularity} automatically binding directories into the container. You
+{Project} automatically binding directories into the container. You
 may need to use ``--bind`` or ``--mount`` to then add back e.g. an HPC
 project directory that you need access to.
 
@@ -743,7 +743,7 @@ project directory that you need access to.
 Environment Propagation
 =======================
 
-{Singularity} propagates most environment variables set on the host into
+{Project} propagates most environment variables set on the host into
 the container, by default. Docker does not propagate any host
 environment variables into the container. Environment variables may
 change the behaviour of software.
@@ -768,21 +768,21 @@ are set in the container:
    FORCE_VAR=123
 
 Any environment variables set via an ``ENV`` line in a ``Dockerfile``
-will be available when the container is run with {Singularity}.
+will be available when the container is run with {Project}.
 
 Namespace & Device Isolation
 ============================
 
-Because {Singularity} favors an integration over isolation approach it
+Because {Project} favors an integration over isolation approach it
 does not, by default, use all the methods through which a container can
 be isolated from the host system. This makes it much easier to run a
-{Singularity} container like any other program, while the unique
+{Project} container like any other program, while the unique
 security model ensures safety. You can access the host's network, GPUs,
 and other devices directly. Processes in the container are not numbered
 separately from host processes. Hostnames are not changed, etc.
 
 Most containers are not impacted by the differences in isolation. If you
-require more isolation, than {Singularity} provides by default, you can
+require more isolation, than {Project} provides by default, you can
 enable some of the extra namespaces that Docker uses, with flags:
 
 -  ``--ipc / -i`` creates a separate IPC (inter process communication)
@@ -811,7 +811,7 @@ directory, rather than binding in the entire host ``/dev`` tree.
 Init Shim Process
 =================
 
-When a {Singularity} container is run using the ``--pid / p`` option, or
+When a {Project} container is run using the ``--pid / p`` option, or
 started as an instance (which implies ``--pid``), a shim init process is
 executed that will run the container payload itself.
 
@@ -819,7 +819,7 @@ The shim process helps to ensure signals are propagated correctly from
 the terminal, or batch schedulers etc. when containers are not designed
 for interactive use. Because Docker does not provide an init process by
 default, some containers have been designed to run their own init
-process, which cannot operate under the control of {Singularity}'s shim.
+process, which cannot operate under the control of {Project}'s shim.
 
 For example, a container using the ``tini`` init process will produce
 warnings when started as an instance, or if run with ``--pid``. To work
@@ -840,7 +840,7 @@ around this, use the ``--no-init`` flag to disable the shim:
  Docker-like ``--compat`` Flag
 *******************************
 
-If Docker-like behavior is important, {Singularity} can be started with
+If Docker-like behavior is important, {Project} can be started with
 the ``--compat`` flag. This flag is a convenient short-hand alternative
 to using all of:
 
@@ -865,7 +865,7 @@ A container run with ``--compat`` has:
 -  No shim init process.
 
 These options will allow most, but not all, Docker / OCI containers to
-execute correctly under {Singularity}. The user namespace and network
+execute correctly under {Project}. The user namespace and network
 namespace are not used, as these negate benefits of SIF and direct
 access to high performance cluster networks.
 
@@ -878,10 +878,10 @@ on the ``CMD`` and/or ``ENTRYPOINT`` set in the ``Dockerfile`` that was
 used to build it, along with any arguments on the command line. The
 ``CMD`` and ``ENTRYPOINT`` can also be overridden by flags.
 
-A {Singularity} container has the concept of a *runscript*, which is a
+A {Project} container has the concept of a *runscript*, which is a
 single shell script defining what happens when you ``singularity run``
 the container. Because there is no internal concept of ``CMD`` and
-``ENTRYPOINT``, {Singularity} must create a runscript from the ``CMD``
+``ENTRYPOINT``, {Project} must create a runscript from the ``CMD``
 and ``ENTRYPOINT`` when converting a Docker container. The behavior of
 this script mirrors Docker as closely as possible.
 
@@ -939,7 +939,7 @@ inside a container.
 Argument Handling
 =================
 
-Because {Singularity} runscripts are evaluated shell scripts
+Because {Project} runscripts are evaluated shell scripts
 arguments can behave slightly differently than in Docker/OCI
 runtimes, if they contain shell code that may be evaluated. To
 replicate Docker/OCI behavior you may need additional escaping or
@@ -963,19 +963,19 @@ runtimes as there is no evaluated runscript.
 .. _sec:best_practices:
 
 *********************************************************
- Best Practices for Docker & {Singularity} Compatibility
+ Best Practices for Docker & {Project} Compatibility
 *********************************************************
 
-As detailed previously, {Singularity} can make use of most Docker and
+As detailed previously, {Project} can make use of most Docker and
 OCI images without issues, or via simple workarounds. In general,
 however, there are some best practices that should be applied when
 creating Docker / OCI containers that will also be run using
-{Singularity}.
+{Project}.
 
    #. **Don't require execution by a specific user**
 
    Avoid using the ``USER`` instruction in your Docker file, as it is
-   ignored by Singularity. Install and configure software inside the
+   ignored by {Project}. Install and configure software inside the
    container so that it can be run by any user.
 
    2. **Don't install software under /root or in another user's home
@@ -988,7 +988,7 @@ creating Docker / OCI containers that will also be run using
    user the software may be inaccessible.
 
    Software inside another user's home directory, e.g. ``/home/myapp``,
-   may be obscured by {Singularity}'s automatic mounts onto ``/home``.
+   may be obscured by {Project}'s automatic mounts onto ``/home``.
 
    Install software into system-wide locations in the container, such as
    under ``/usr`` or ``/opt`` to avoid these issues.
@@ -996,7 +996,7 @@ creating Docker / OCI containers that will also be run using
    3. **Support a read-only filesystem**
 
    Because of the immutable nature of the SIF format, a container run
-   with {Singularity} is read-only by default.
+   with {Project} is read-only by default.
 
    Try to ensure your container will run with a read-only filesystem. If
    this is not possible, document exactly where the container needs to
@@ -1008,7 +1008,7 @@ creating Docker / OCI containers that will also be run using
 
    4. **Be careful writing to /tmp**
 
-   {Singularity} mounts the *host* ``/tmp`` into the container, by
+   {Project} mounts the *host* ``/tmp`` into the container, by
    default. This means you must be be careful when writing sensitive
    information to ``/tmp``, and should ensure your container cleans up
    files it writes there.
@@ -1019,7 +1019,7 @@ creating Docker / OCI containers that will also be run using
    search path in the container (``ld.so.conf`` / ``ld.so.conf.d``), you
    should ensure the library cache is updated during the build.
 
-   Because Singularity runs containers read-only by default, the cache
+   Because {Project} runs containers read-only by default, the cache
    and any missing library symlinks may not be able to be updated /
    created at execution time.
 
@@ -1052,7 +1052,7 @@ Container Doesn't Start
 =======================
 
 If a Docker container fails to start, the most common cause is that it
-needs to write files, while {Singularity} runs read-only by default.
+needs to write files, while {Project} runs read-only by default.
 
 Try running with the ``--writable-tmpfs`` option, or the ``--compat``
 flag (which enables additional compatibility fixes).
@@ -1067,7 +1067,7 @@ Unexpected Container Behaviour
 ==============================
 
 If a Docker container runs, but exhibits unexpected behavior, the most
-likely cause is the different level of isolation that Singularity
+likely cause is the different level of isolation that {Project}
 provides vs Docker.
 
 Try running the container with the ``--contain`` option, or the
@@ -1083,25 +1083,25 @@ The community Slack channels and mailing list are excellent places to
 ask for help with running a specific Docker container. Other users may
 have already had success running the same container or software. Please
 don't report issues with specific Docker containers on GitHub, unless
-you believe they are due to a bug in {Singularity}.
+you believe they are due to a bug in {Project}.
 
 .. _sec:deffile-vs-dockerfile:
 
 **********************************************
- {Singularity} Definition file vs. Dockerfile
+ {Project} Definition file vs. Dockerfile
 **********************************************
 
-An alternative to running Docker containers with {Singularity} is to
+An alternative to running Docker containers with {Project} is to
 re-write the ``Dockerfile`` as a definition file, and build a native SIF
 image.
 
 The table below gives a quick reference comparing Dockerfile and
-{Singularity} definition files. For more detail please see
+{Project} definition files. For more detail please see
 :ref:`definition-files`.
 
 
 ================ =========================== ================ =============================
-{Singularity} Definition file                Dockerfile
+{Project} Definition file                Dockerfile
 -------------------------------------------- ----------------------------------------------
 Section          Description                 Section          Description
 ================ =========================== ================ =============================


### PR DESCRIPTION
This change the `{Singularity}` replacement variable to `{Project}` and sets the value to Apptainer.  There were also a number of places where `Singularity` was used without the replacement variable, those are also changed.

- Fixes #38 