### PR TITLE
Reintroduce separate rst lint step

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,11 @@ jobs:
 
       - name: Install Sphinx
         run: |
-          pip install --user --upgrade --upgrade-strategy eager sphinx sphinx-rtd-theme restructuredtext_lint pygments
+          pip install --user --upgrade --upgrade-strategy eager sphinx sphinx-rtd-theme restructuredtext_lint rstcheck pygments
+
+      - name: Lint rst
+        run: |
+          rstcheck --ignore-language c,c++ --report warning *.rst
 
       - name: Build web documentation
         run: |

--- a/appendix.rst
+++ b/appendix.rst
@@ -186,7 +186,7 @@ below with their respective functionality.
    is set to our Cloud Library.
 
 ``M``
-^^^^^
+=====
 
 #. **SINGULARITY_MOUNT**: To specify host to container mounts, using the
    syntax understood by the ``--mount`` flag. Multiple mounts should be


### PR DESCRIPTION
I noticed when running `make html` manually that there were lint errors and warnings and nothing failed.  This reintroduces invoking `rstcheck` during the CI tests the way that Sylabs does it on CircleCI.  It leaves the separate `restructuretest_lint` still in place because that prints additional warnings during the build step.