### PR TITLE
Clarify Docker ENV / host env var override, from sylabs 70

### DIFF
--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -90,6 +90,15 @@ This happens because the ``Dockerfile`` used to build that container has
 You can always override the value of these base image environment
 variables, if needed. See below.
 
+.. note::
+
+   Dockerfile `ENV` var entries are set as :ref:`default values
+   <environment-default-values>` in the {Project} container. They will be
+   overridden by host variables unless ``-e / --cleanenv`` or the ``--containall
+   / --compat`` flags are used. This differs from the behavior of Docker, and
+   you should consider using ``--compat`` if you experience issues when running
+   Docker containers dues to environment variables on the host.
+
 ************************************
  Environment from a definition file
 ************************************
@@ -127,6 +136,8 @@ The ``%runscript`` is set to echo the value.
    initialization tasks because this would impact users running the
    image and the execution could abort due to timeout.
 
+
+.. _environment-default-values:
 
 Default values
 ==============
@@ -168,10 +179,15 @@ If you have environment variables set outside of your container, on the
 host, then by default they will be available inside the container.
 Except that:
 
-   -  An environment variable set on the host will be overridden by a
-      variable of the same name that has been set inside the container
-      image, via ``APPTAINERENV_`` environment variables, or the
-      ``--env`` and ``--env-file`` flags.
+   -  An environment variable set on the host will be overridden by a variable
+      of the same name that has been set either inside the container image, or
+      via ``APPTAINERENV_`` environment variables, or the ``--env`` and
+      ``--env-file`` flags.
+
+   -  You can use the :ref:`default values <environment-default-values>` method
+      to define container environment variables that avoid the hard override,
+      and honor the value of an environment variable value from the host if it
+      is set.
 
    -  The ``PS1`` shell prompt is reset for a container specific prompt.
 
@@ -202,6 +218,14 @@ environment variables for correct operation of most software.
    APPTAINER_ENVIRONMENT=/.singularity.d/env/91-environment.sh
    APPTAINER_NAME=env.sif
    TERM=xterm-256color
+
+.. note::
+
+   Because Dockerfile `ENV` var entries are set as
+   :ref:`default values <environment-default-values>` in the {Project}
+   container, they will be overridden by host variables unless
+   ``-e / --cleanenv`` or the related ``--containall / --compat`` flags are
+   used.
 
 .. warning::
 

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -767,8 +767,11 @@ are set in the container:
    $ singularity run --cleanenv library://alpine env | grep VAR
    FORCE_VAR=123
 
-Any environment variables set via an ``ENV`` line in a ``Dockerfile``
-will be available when the container is run with {Project}.
+Any environment variables set via an ``ENV`` line in a ``Dockerfile`` will be
+available when the container is run with {Project}. However, because they
+are set as :ref:`default values <environment-default-values>` in the
+{Project} container, they will be overridden by host variables unless ``-e /
+--cleanenv`` or the related ``--containall / --compat`` flags are used.
 
 Namespace & Device Isolation
 ============================


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-userdocs#70
 which fixed
- sylabs/singularity-userdocs#69