### PR TITLE
Rename singularity to {command}

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -7,7 +7,7 @@
 ..
    TODO oci & oci-archive along with http & https
 
-.. _apptainer-environment-variables:
+.. _{command}-environment-variables:
 
 ***************************************
  {Project}'s environment variables
@@ -357,14 +357,14 @@ existing base container adding customizations in ``%post``,
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: library
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    From: <entity>/<collection>/<container>:<tag>
 
@@ -374,14 +374,14 @@ a base. ``entity`` is optional and defaults to ``library``.
 correct namespace to use for some official containers (``alpine`` for
 example). ``tag`` is also optional and will default to ``latest``.
 
-.. code:: apptainer
+.. code:: {command}
 
    Library: http://custom/library
 
 The Library keyword is optional. It will default to
 ``https://library.sylabs.io``.
 
-.. code:: apptainer
+.. code:: {command}
 
    Fingerprints: 22045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
 
@@ -419,14 +419,14 @@ Docker containers. If so, you can seamlessly convert them to
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: docker
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    From: <registry>/<namespace>/<container>:<tag>@<digest>
 
@@ -439,14 +439,14 @@ example). ``tag`` is also optional and will default to ``latest``
 See :ref:`{Project} and Docker <singularity-and-docker>` for more
 detailed info on using Docker registries.
 
-.. code:: apptainer
+.. code:: {command}
 
    Registry: http://custom_registry
 
 The Registry keyword is optional. It will default to
 ``index.docker.io``.
 
-.. code:: apptainer
+.. code:: {command}
 
    Namespace: namespace
 
@@ -490,14 +490,14 @@ container adding customizations in ``%post`` , ``%environment``,
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: shub
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    From: shub://<registry>/<username>/<container-name>:<tag>@digest
 
@@ -538,14 +538,14 @@ containers by adding customizations in ``%post`` , ``%environment``,
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: oras
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    From: oras://registry/namespace/image:tag
 
@@ -580,21 +580,21 @@ container and then customize the new container in ``%post``,
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: localimage
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    From: /path/to/container/file/or/directory
 
 The ``From`` keyword is mandatory. It specifies the local container to
 use as a base.
 
-.. code:: apptainer
+.. code:: {command}
 
    Fingerprints: 22045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
 
@@ -633,14 +633,14 @@ You must also specify the URI for the mirror you would like to use.
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: yum
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    OSVersion: 7
 
@@ -648,7 +648,7 @@ The OSVersion keyword is optional. It specifies the OS version you would
 like to use. It is only required if you have specified a %{OSVERSION}
 variable in the ``MirrorURL`` keyword.
 
-.. code:: apptainer
+.. code:: {command}
 
    MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
 
@@ -656,7 +656,7 @@ The MirrorURL keyword is mandatory. It specifies the URI to use as a
 mirror to download the OS. If you define the ``OSVersion`` keyword, then
 you can use it in the URI as in the example above.
 
-.. code:: apptainer
+.. code:: {command}
 
    Include: yum
 
@@ -707,14 +707,14 @@ you would like to use.
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: debootstrap
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    OSVersion: xenial
 
@@ -724,14 +724,14 @@ would like to use. For Ubuntu you can use code words like ``trusty``
 use values like ``stable``, ``oldstable``, ``testing``, and ``unstable``
 or code words like ``wheezy`` (7), ``jesse`` (8), and ``stretch`` (9).
 
-   .. code:: apptainer
+   .. code:: {command}
 
       MirrorURL:  http://us.archive.ubuntu.com/ubuntu/
 
 The MirrorURL keyword is mandatory. It specifies a URI to use as a
 mirror when downloading the OS.
 
-.. code:: apptainer
+.. code:: {command}
 
    Include: somepackage
 
@@ -776,7 +776,7 @@ container. Arch Linux uses the aptly named ``pacman`` package manager
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: arch
 
@@ -817,14 +817,14 @@ must also specify a URI for the mirror you would like to use.
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: busybox
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    MirrorURL: https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64
 
@@ -861,14 +861,14 @@ You must also specify a URI for the mirror you would like to use.
 Keywords
 --------
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: zypper
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap
 module to use.
 
-.. code:: apptainer
+.. code:: {command}
 
    OSVersion: 42.2
 
@@ -876,7 +876,7 @@ The OSVersion keyword is optional. It specifies the OS version you would
 like to use. It is only required if you have specified a %{OSVERSION}
 variable in the ``MirrorURL`` keyword.
 
-.. code:: apptainer
+.. code:: {command}
 
    Include: somepackage
 
@@ -908,7 +908,7 @@ currently residing in docker's daemon internal storage:
    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
    alpine              latest              965ea09ff2eb        7 weeks ago         5.55MB
 
-   $ singularity run docker-daemon:alpine:latest
+   $ {command} run docker-daemon:alpine:latest
    INFO:    Converting OCI blobs to SIF format
    INFO:    Starting build...
    Getting image source signatures
@@ -927,7 +927,7 @@ a docker image stored in a ``docker-save`` formatted tar file:
 
    $ docker save -o alpine.tar alpine:latest
 
-   $ singularity run docker-archive:$(pwd)/alpine.tar
+   $ {command} run docker-archive:$(pwd)/alpine.tar
    INFO:    Converting OCI blobs to SIF format
    INFO:    Starting build...
    Getting image source signatures
@@ -945,7 +945,7 @@ Keywords
 The ``docker-daemon`` bootstrap agent can be used in a {Project}
 definition file as follows:
 
-.. code:: apptainer
+.. code:: {command}
 
    From: docker-daemon:<image>:<tag>
 
@@ -953,7 +953,7 @@ where both ``<image>`` and ``<tag>`` are mandatory fields that must be
 written explicitly. The ``docker-archive`` bootstrap agent requires
 instead the path to the tar file containing the image:
 
-.. code:: apptainer
+.. code:: {command}
 
    From: docker-archive:<path-to-tar-file>
 
@@ -978,7 +978,7 @@ Overview
 A minimal container providing a shell can be created by copying the
 ``busybox`` static binary into an empty scratch container:
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: scratch
 
@@ -1002,7 +1002,7 @@ The resulting container provides a shell, and is 696KiB in size:
    $ ls -lah scratch.sif
    -rwxr-xr-x. 1 dave dave 696K May 28 13:29 scratch.sif
 
-   $ apptainer run scratch.sif
+   $ {command} run scratch.sif
    WARNING: passwd file doesn't exist in container, not updating
    WARNING: group file doesn't exist in container, not updating
    {Project}> echo "Hello from a 696KiB container"
@@ -1010,7 +1010,7 @@ The resulting container provides a shell, and is 696KiB in size:
 
 Keywords
 
-.. code:: apptainer
+.. code:: {command}
 
    Bootstrap: scratch
 

--- a/appendix.rst
+++ b/appendix.rst
@@ -436,7 +436,7 @@ a base. ``registry`` is optional and defaults to ``index.docker.io``.
 correct namespace to use for some official containers (ubuntu for
 example). ``tag`` is also optional and will default to ``latest``
 
-See :ref:`{Project} and Docker <singularity-and-docker>` for more
+See :ref:`{Project} and Docker <docker-and-oci>` for more
 detailed info on using Docker registries.
 
 .. code:: {command}

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -43,7 +43,7 @@ Disabling System Binds
 
 The ``--no-mount`` flag allows specific
 system mounts to be disabled, even if they are set in the
-``singularity.conf`` configuration file by the administrator.
+``{command}.conf`` configuration file by the administrator.
 
 For example, if {Project} has been configured with ``mount hostfs =
 yes`` then every filesystem on the host will be bind mounted to the
@@ -53,13 +53,13 @@ running, you can disable the ``hostfs`` binds:
 
 .. code:: console
 
-   $ singularity run --no-mount hostfs mycontainer.sif
+   $ {command} run --no-mount hostfs mycontainer.sif
 
 Multiple mounts can be disabled by specifying them separated by commas:
 
 .. code:: console
 
-   $ singularity run --no-mount tmp,sys,dev mycontainer.sif
+   $ {command} run --no-mount tmp,sys,dev mycontainer.sif
 
 .. _user-defined-bind-paths:
 
@@ -101,14 +101,14 @@ already exist in the container):
    $ ls /data
    bar  foo
 
-   $ singularity exec --bind /data:/mnt my_container.sif ls /mnt
+   $ {command} exec --bind /data:/mnt my_container.sif ls /mnt
    bar  foo
 
 You can bind multiple directories in a single command with this syntax:
 
 .. code::
 
-   $ singularity shell --bind /opt,/data:/mnt my_container.sif
+   $ {command} shell --bind /opt,/data:/mnt my_container.sif
 
 This will bind ``/opt`` on the host to ``/opt`` in the container and
 ``/data`` on the host to ``/mnt`` in the container.
@@ -120,7 +120,7 @@ this would be:
 
    $ export {ENVPREFIX}_BIND="/opt,/data:/mnt"
 
-   $ singularity shell my_container.sif
+   $ {command} shell my_container.sif
 
 Using the environment variable ``${ENVPREFIX}_BIND``, you can bind paths
 even when you are running your container as an executable file with a
@@ -145,7 +145,7 @@ To mount ``data`` on the host to ``/mnt`` inside the container:
 
 .. code::
 
-   $ singularity exec \
+   $ {command} exec \
        --mount type=bind,src=/data,dst=/mnt \
        my_container.sif ls /mnt
    bar  foo
@@ -155,7 +155,7 @@ option:
 
 .. code::
 
-   $ singularity exec \
+   $ {command} exec \
        --mount type=bind,source=/data,dest=/mnt,ro \
        my_container.sif touch /mnt/test
    touch: cannot touch '/mnt/test': Permission denied
@@ -165,7 +165,7 @@ You can bind multiple directories in a single command with multiple
 
 .. code::
 
-   $ singularity shell --mount type=bind,src=/opt,dst=/opt \
+   $ {command} shell --mount type=bind,src=/opt,dst=/opt \
                        --mount type=bind,src=/data,dst=/data \
                        my_container.sif
 
@@ -180,12 +180,12 @@ wrapping each field in double quotes if necessary characters.
 .. code::
 
    # Mount a path containing ':' (not possible with --bind)
-   $ singularity run \
+   $ {command} run \
        --mount type=bind,src=/my:path,dst=/mnt \
        mycontainer.sif
 
    # Mount a path containing a ','
-   $ singularity run \
+   $ {command} run \
        --mount type=bind,"src=/comma,dir",dst=/mnt \
        mycontainer.sif
 
@@ -226,7 +226,7 @@ host ``$HOME`` directory with the ``--no-home`` flag.
 
 .. code::
 
-   $ singularity shell --no-home my_container.sif
+   $ {command} shell --no-home my_container.sif
 
 .. note::
 
@@ -245,7 +245,7 @@ host ``$HOME`` directory with the ``--no-home`` flag.
 
 .. code::
 
-   $ singularity shell --containall my_container.sif
+   $ {command} shell --containall my_container.sif
 
 *************
  FUSE mounts
@@ -328,7 +328,7 @@ type:
 
 .. code::
 
-   $ singularity run --fusemount "host:sshfs server:/ /server" docker://ubuntu
+   $ {command} run --fusemount "host:sshfs server:/ /server" docker://ubuntu
    {Project}> cat /etc/hostname
    localhost.localdomain
    {Project}> cat /server/etc/hostname
@@ -342,7 +342,7 @@ added to your container, you can use the ``container`` mount type:
 
 .. code::
 
-   $ singularity run --fusemount "container:sshfs server:/ /server" sshfs.sif
+   $ {command} run --fusemount "container:sshfs server:/ /server" sshfs.sif
    {Project}> cat /etc/hostname
    localhost.localdomain
    {Project}> cat /server/etc/hostname
@@ -411,13 +411,13 @@ wish to distribute in an image file that allows read/write:
 
    # Run {Project}, mounting my input data to '/input-data' in
    # the container.
-   $ singularity run -B inputs.img:/input-data:image-src=/ mycontainer.sif
+   $ {command} run -B inputs.img:/input-data:image-src=/ mycontainer.sif
    {Project}> ls /input-data
    1           3           5           7           9
    2           4           6           8           lost+found
 
    # Or with --mount instead of -B
-   $ singularity run \
+   $ {command} run \
        --mount type=bind,src=inputs.img,dst=/input-data,image-src=/ \
        mycontainer.sif
 
@@ -439,12 +439,12 @@ then the squashfs format is appropriate:
 
    # Run {Project}, mounting my input data to '/input-data' in
    # the container.
-   $ singularity run -B inputs.squashfs:/input-data:image-src=/ mycontainer.sif
+   $ {command} run -B inputs.squashfs:/input-data:image-src=/ mycontainer.sif
    {Project}> ls /input-data/
    1  2  3  4  5  6  7  8  9
 
    # Or with --mount instead of -B
-   $ singularity run \
+   $ {command} run \
        --mount type=bind,src=src-inputs.squashfs,dst=/input-data,image-src=/ \
        mycontainer.sif
 
@@ -453,24 +453,24 @@ SIF Image Files
 
 Advanced users may wish to create a standalone SIF image, which contains
 an ``ext3`` or ``squashfs`` data partition holding files, by using the
-``singularity sif`` commands similarly to the :ref:`persistent overlays
+``apptainer sif`` commands similarly to the :ref:`persistent overlays
 instructions <overlay-sif>`:
 
 .. code:: console
 
    # Create a new empty SIF file
-   $ singularity sif new inputs.sif
+   $ {command} sif new inputs.sif
 
    # Add the squashfs data image from above to the SIF
-   $ singularity sif add --datatype 4 --partarch 2 --partfs 1 --parttype 3 inputs.sif inputs.squashfs
+   $ {command} sif add --datatype 4 --partarch 2 --partfs 1 --parttype 3 inputs.sif inputs.squashfs
 
    # Run {Project}, binding data from the SIF file
-   $ singularity run -B inputs.sif:/input-data:image-src=/ mycontainer.sif
+   $ {command} run -B inputs.sif:/input-data:image-src=/ mycontainer.sif
    {Project}> ls /input-data
    1  2  3  4  5  6  7  8  9
 
    # Or with --mount instead of -B
-   $ singularity run \
+   $ {command} run \
        --mount type=bind,src=inputs.sif,dst=/input-data,image-src=/ \
        mycontainer.sif
 

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -53,7 +53,7 @@ Library.
 
 .. code::
 
-   $ sudo singularity build lolcow.sif library://lolcow
+   $ sudo {command} build lolcow.sif library://lolcow
 
 The first argument (``lolcow.sif``) specifies a path and name for your
 container. The second argument (``library://lolcow``) gives the
@@ -70,7 +70,7 @@ them into {Project} containers.
 
 .. code::
 
-   $ sudo singularity build lolcow.sif docker://sylabsio/lolcow
+   $ sudo {command} build lolcow.sif docker://sylabsio/lolcow
 
 .. _create_a_writable_container:
 
@@ -85,7 +85,7 @@ permissions it is recommended to do so as root.
 
 .. code::
 
-   $ sudo singularity build --sandbox lolcow/ library://lolcow
+   $ sudo {command} build --sandbox lolcow/ library://lolcow
 
 The resulting directory operates just like a container in a SIF file. To
 make changes within the container, use the ``--writable`` flag when you
@@ -95,7 +95,7 @@ change.
 
 .. code::
 
-   $ sudo singularity shell --writable lolcow/
+   $ sudo {command} shell --writable lolcow/
 
 **************************************************
  Converting containers from one format to another
@@ -109,7 +109,7 @@ one format to another. For example if you had a sandbox container called
 
 .. code::
 
-   $ sudo singularity build production.sif development/
+   $ sudo {command} build production.sif development/
 
 Use care when converting a sandbox directory to the default SIF format.
 If changes were made to the writable container before conversion, there
@@ -129,7 +129,7 @@ definition files, please see the :doc:`Container Definition docs
 definition file called ``lolcow.def``, and you want to use it to build a
 SIF container.
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: ubuntu:16.04
@@ -149,7 +149,7 @@ You can do so with the following command.
 
 .. code::
 
-   $ sudo singularity build lolcow.sif lolcow.def
+   $ sudo {command} build lolcow.sif lolcow.def
 
 The command requires ``sudo`` just as installing software on your local
 machine requires root privileges.

--- a/build_env.rst
+++ b/build_env.rst
@@ -37,10 +37,10 @@ variable, if you set it.
    $ export {ENVPREFIX}_CACHEDIR=/tmp/user/temporary-cache
 
    # Running a build under your user account
-   $ singularity build --fakeroot myimage.sif mydef.def
+   $ {command} build --fakeroot myimage.sif mydef.def
 
    # Running a build with sudo, must use -E to pass env var
-   $ sudo -E singularity build myimage.sif mydef.def
+   $ sudo -E {command} build myimage.sif mydef.def
 
 If you change the value of ``{ENVPREFIX}_CACHEDIR`` be sure to choose a
 location that is:
@@ -59,7 +59,7 @@ location that is:
    If you are not certain that your ``$HOME`` or
    ``{ENVPREFIX}_CACHEDIR`` filesystems support atomic rename, do not
    run {Project} in parallel using remote container URLs. Instead
-   use ``singularity pull`` to create a local SIF image, and then run
+   use ``{command} pull`` to create a local SIF image, and then run
    this SIF image in a parallel step. An alternative is to use the
    ``--disable-cache`` option, but this will result in each
    {Project} instance independently fetching the container from the
@@ -82,7 +82,7 @@ future runs.
 
 You should not add any additional files, or modify files in the cache,
 as this may cause checksum / integrity errors when you run or build
-containers. If you experience problems use ``singularity cache clean``
+containers. If you experience problems use ``{command} cache clean``
 to reset the cache to a clean, empty state.
 
 BoltDB Corruption Errors
@@ -119,19 +119,19 @@ your cache, without manually inspecting the cache directories.
 Listing Cache
 =============
 
-To view a summary of cache usage, use ``singularity cache list``:
+To view a summary of cache usage, use ``{command} cache list``:
 
 .. code::
 
-   $ singularity cache list
+   $ {command} cache list
    There are 4 container file(s) using 59.45 MB and 23 oci blob file(s) using 379.10 MB of space
    Total space used: 438.55 MB
 
-To view detailed information, use ``singularity cache list -v``:
+To view detailed information, use ``{command} cache list -v``:
 
 .. code::
 
-   $ singularity cache list -v
+   $ {command} cache list -v
    NAME                     DATE CREATED           SIZE             TYPE
    0ed5a98249068fe0592edb   2020-05-27 12:57:22    192.21 MB        blob
    1d9cd1b99a7eca56d8f2be   2020-05-28 15:19:07    0.35 kB          blob
@@ -178,15 +178,15 @@ You can limit the cache list to a specific cache type with the ``-type``
 Cleaning the Cache
 ==================
 
-To reclaim space used by the {Project} cache, use ``singularity
+To reclaim space used by the {Project} cache, use ``{command}
 cache clean``.
 
-By default ``singularity cache clean`` will remove all cache entries,
+By default ``{command} cache clean`` will remove all cache entries,
 after asking you to confirm:
 
 .. code::
 
-   $ singularity cache clean
+   $ {command} cache clean
    This will delete everything in your cache (containers from all sources and OCI blobs).
    Hint: You can see exactly what would be deleted by canceling and using the --dry-run option.
    Do you want to continue? [N/y] n
@@ -201,14 +201,14 @@ option. E.g. to clean cache entries older than 30 days:
 
 .. code::
 
-   $ singularity cache clean --days 30
+   $ {command} cache clean --days 30
 
 To remove only a specific kind of cache entry, e.g. only library images,
 use the ``type`` / ``-T`` option:
 
 .. code::
 
-   $ singularity cache clean --type library
+   $ {command} cache clean --type library
 
 .. _sec:temporaryfolders:
 

--- a/build_env.rst
+++ b/build_env.rst
@@ -23,7 +23,7 @@ other topics related to the build environment.
 
 {Project} will cache SIF container images generated from remote
 sources, and any OCI/docker layers used to create them. The cache is
-created at ``$HOME/.singularity/cache`` by default. The location of the
+created at ``$HOME/.{command}/cache`` by default. The location of the
 cache can be changed by setting the ``{ENVPREFIX}_CACHEDIR`` environment
 variable.
 
@@ -70,11 +70,11 @@ different kinds of data that are cached:
 
 .. code::
 
-   $HOME/.singularity/cache/blob
-   $HOME/.singularity/cache/library
-   $HOME/.singularity/cache/net
-   $HOME/.singularity/cache/oci-tmp
-   $HOME/.singularity/cache/shub
+   $HOME/.{command}/cache/blob
+   $HOME/.{command}/cache/library
+   $HOME/.{command}/cache/net
+   $HOME/.{command}/cache/oci-tmp
+   $HOME/.{command}/cache/shub
 
 You can safely delete these directories, or content within them.
 {Project} will re-create any directories and data that are needed in
@@ -112,7 +112,7 @@ your cache, without manually inspecting the cache directories.
 .. note::
 
    If you have built images as root, directly or via ``sudo``, the cache
-   location for those builds is ``/root/.singularity``. You will need to
+   location for those builds is ``/root/.{command}``. You will need to
    use ``sudo`` when running ``cache clean`` or ``cache list`` to manage
    these cache entries.
 

--- a/cgroups.rst
+++ b/cgroups.rst
@@ -27,9 +27,9 @@ processes.
 
 Because {Project} starts a container as a simple process, rather
 than using a daemon, you can limit resource usage by running the
-``singularity`` command inside an existing cgroup. This is convenient
+``{command}`` command inside an existing cgroup. This is convenient
 where, for example, a job scheduler uses cgroups to control job limits.
-By running ``singularity`` inside your batch script, your container will
+By running ``{command}`` inside your batch script, your container will
 respect the limits set by the scheduler on the job's cgroup.
 
 systemd-run
@@ -47,7 +47,7 @@ CPUs a container run is allowed to use:
 
 .. code::
 
-   $ systemd-run --user --scope -p AllowedCPUs=1,2 -- singularity run mycontainer.sif
+   $ systemd-run --user --scope -p AllowedCPUs=1,2 -- {command} run mycontainer.sif
 
 -  ``--user`` instructs systemd that we want to run as our own user
    account.
@@ -63,7 +63,7 @@ CPUs a container run is allowed to use:
 -  The double hyphen ``--`` separates options for ``systemd-run`` from
    the actual command we wish to execute. This is important so that
    ``systemd-run`` doesn't capture any flags we might need to pass to
-   ``singularity``.
+   ``{command}``.
 
 You can read more about how systemd can control resources uses at the
 link below, which details the properties you can set using
@@ -105,7 +105,7 @@ configuration to be applied:
 
 .. code::
 
-   $ sudo singularity shell --apply-cgroups /path/to/cgroups.toml my_container.sif
+   $ sudo {command} shell --apply-cgroups /path/to/cgroups.toml my_container.sif
 
 .. note::
 
@@ -127,21 +127,21 @@ Start your container, applying the toml file, e.g.:
 
 .. code::
 
-   $ sudo singularity run --apply-cgroups path/to/cgroups.toml library://alpine
+   $ sudo {command} run --apply-cgroups path/to/cgroups.toml library://alpine
 
 After that, you can verify that the container is only using 500MB of
 memory. This example assumes that there is only one running container.
 If you are running multiple containers you will find multiple cgroups
-trees under the ``singularity`` directory.
+trees under the ``{command}`` directory.
 
 .. code::
 
    # cgroups v1
-   $ cat /sys/fs/cgroup/memory/singularity/*/memory.limit_in_bytes
+   $ cat /sys/fs/cgroup/memory/{command}/*/memory.limit_in_bytes
      524288000
 
    # cgroups v2 - note translation of memory.limit_in_bytes -> memory.max
-   $ cat /sys/fs/cgroup/singularity/*/memory.max
+   $ cat /sys/fs/cgroup/{command}/*/memory.max
    524288000
 
 Limiting CPU

--- a/cloud_library.rst
+++ b/cloud_library.rst
@@ -44,7 +44,7 @@ To generate a access token, do the following steps:
    #. Enter a name for your new access token, such as "test token"
    #. Click the "Create a New Access Token" button.
    #. Click "Copy token to Clipboard" from the "New API Token" page.
-   #. Run ``singularity remote login`` and paste the access token at the
+   #. Run ``{command} remote login`` and paste the access token at the
       prompt.
 
 Now that you have your token, you are ready to push your container!
@@ -55,12 +55,12 @@ Now that you have your token, you are ready to push your container!
  Pushing a Container
 *********************
 
-The ``singularity push`` command will push a container to the container
+The ``{command} push`` command will push a container to the container
 library with the given URL. Here's an example of a typical push command:
 
 .. code::
 
-   $ singularity push my-container.sif library://your-name/project-dir/my-container:latest
+   $ {command} push my-container.sif library://your-name/project-dir/my-container:latest
 
 The ``:latest`` is the container tag. Tags are used to have different
 version of the same container.
@@ -78,7 +78,7 @@ a version tag to that container, like so:
 
 .. code::
 
-   $ singularity push my-container.sif library://your-name/project-dir/my-container:1.0.1
+   $ {command} push my-container.sif library://your-name/project-dir/my-container:1.0.1
 
 You can download the container with that tag by replacing the
 ``:latest``, with the tagged container you want to download.
@@ -89,7 +89,7 @@ to setting the description via the web interface:
 
 .. code:: console
 
-   $ singularity push -D "My alpine 3.11 container" alpine_3.11.sif library://myuser/examples/alpine:3.11
+   $ {command} push -D "My alpine 3.11 container" alpine_3.11.sif library://myuser/examples/alpine:3.11
    2.7MiB / 2.7MiB [=========================================================================] 100 % 1.1 MiB/s 0s
 
    Library storage: using 13.24 MiB out of 11.00 GiB quota (0.1% used)
@@ -105,7 +105,7 @@ container in your web browser.
  Pulling a container
 *********************
 
-The ``singularity pull`` command will download a container from the
+The ``{command} pull`` command will download a container from the
 `Library <https://cloud.sylabs.io/library>`_ (``library://``), `Docker
 Hub <https://hub.docker.com/>`_ (``docker://``), and also `Shub
 <https://singularity-hub.org>`_ (``shub://``).
@@ -119,11 +119,11 @@ Here's a typical pull command:
 
 .. code::
 
-   $ singularity pull file-out.sif library://alpine:latest
+   $ {command} pull file-out.sif library://alpine:latest
 
    # or pull from docker:
 
-   $ singularity pull file-out.sif docker://alpine:latest
+   $ {command} pull file-out.sif docker://alpine:latest
 
 .. note::
 
@@ -135,7 +135,7 @@ URL:
 
 .. code::
 
-   $ singularity pull file-out.sif library://alpine:3.8
+   $ {command} pull file-out.sif library://alpine:3.8
 
 Of course, you can pull your own containers. Here's what that will look
 like:
@@ -148,11 +148,11 @@ etc...
 
 .. code::
 
-   $ singularity pull out-file.sif library://your-name/project-dir/my-container:latest
+   $ {command} pull out-file.sif library://your-name/project-dir/my-container:latest
 
    # or use a different tag:
 
-   $ singularity pull out-file.sif library://your-name/project-dir/my-container:1.0.1
+   $ {command} pull out-file.sif library://your-name/project-dir/my-container:1.0.1
 
 .. note::
 
@@ -181,7 +181,7 @@ To find interesting or useful containers in the library, you can open
 https://cloud.sylabs.io/library in your browser and search from there
 through the web GUI.
 
-Alternatively, from the CLI you can use ``singularity search <query>``.
+Alternatively, from the CLI you can use ``{command} search <query>``.
 This will search the library for container images matching ``<query>``.
 
 Using the CLI Search
@@ -191,7 +191,7 @@ Here is an example of searching the library for ``centos``:
 
 .. code:: console
 
-   singularity search centos
+   {command} search centos
    Found 72 container images for amd64 matching "centos":
 
        library://dcsouthwick/iotools/centos7:latest
@@ -217,7 +217,7 @@ Containers can have multiple tags, and these are shown separated by
 commas after the ``:`` in the URL. E.g.
 ``library://dtrudg/linux/centos:7,centos7,latest`` is a single container
 image with 3 tags, ``7``, ``centos7``, and ``latest``. You can
-``singularity pull`` the container image using any one of these tags.
+``{command} pull`` the container image using any one of these tags.
 
 Note that the results show ``amd64`` containers only. By default
 ``search`` returns only containers with an architecture matching your
@@ -226,7 +226,7 @@ current system. To e.g. search for ``arm64`` containers from an
 
 .. code:: console
 
-   singularity search --arch arm64 alpine
+   {command} search --arch arm64 alpine
    Found 5 container images for arm64 matching "alpine":
 
        library://dtrudg-sylabs-2/multiarch/alpine:latest
@@ -245,7 +245,7 @@ You can also limit results to only signed containers with the
 
 .. code:: console
 
-   singularity search --signed alpine
+   {command} search --signed alpine
    Found 45 container images for amd64 matching "alpine":
 
        library://deep/default/alpine:latest,1.0.1
@@ -274,7 +274,7 @@ Building from a definition file:
 
 This is our definition file. Let's call it ``ubuntu.def``:
 
-.. code:: singularity
+.. code:: {command}
 
    bootstrap: library
    from: ubuntu:18.04
@@ -287,7 +287,7 @@ Now, to build the container, use the ``--remote`` flag, and without
 
 .. code::
 
-   $ singularity build --remote ubuntu.sif ubuntu.def
+   $ {command} build --remote ubuntu.sif ubuntu.def
 
 .. note::
 

--- a/conf.py
+++ b/conf.py
@@ -202,7 +202,7 @@ html_show_copyright = False
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'singularity-' + version + '-user-guide'
+htmlhelp_basename = '{command}-' + version + '-user-guide'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -266,7 +266,7 @@ epub_publisher = author
 epub_copyright = copyright
 
 # The basename for the epub file. It defaults to the project name.
-epub_basename = 'singularity-' + version + '-user-guide'
+epub_basename = '{command}-' + version + '-user-guide'
 
 # The HTML theme for the epub output.
 # Since the default themes are not optimized for small screen space,

--- a/conf.py
+++ b/conf.py
@@ -292,9 +292,9 @@ epub_exclude_files = []
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
 from sphinx.highlighting import lexers
-from pygments_singularity import SingularityLexer
+from pygments_apptainer import ApptainerLexer
 from pygments_json import JSONLexer
 from replacements import *
-# lexer for Singularity definition files (added here until it is upstreamed into Pygments).
-lexers['singularity'] = SingularityLexer(startinline=True)
+# lexer for Apptainer definition files (added here until it is upstreamed into Pygments).
+lexers['apptainer'] = ApptainerLexer(startinline=True)
 lexers['json'] = JSONLexer(startinline=True)

--- a/contributing.rst
+++ b/contributing.rst
@@ -111,8 +111,8 @@ username.)
 
 .. code::
 
-   $ git clone https://github.com/your-username/singularity.git && \
-       cd singularity/
+   $ git clone https://github.com/your-username/{command}.git && \
+       cd {command}/
 
 Step 2. Checkout a new branch
 =============================
@@ -203,7 +203,7 @@ you need to update a branch, you will need to follow the next steps:
 
 .. code::
 
-   $ git remote add upstream https://github.com/hpcng/singularity.git && # to add a new remote named "upstream" \
+   $ git remote add upstream https://github.com/apptainer/apptainer.git && # to add a new remote named "upstream" \
        git checkout master && # or another branch to be updated \
        git pull upstream master && \
        git push origin master && # to update your fork \

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -66,7 +66,7 @@ bootstrap agent, the ``From`` keyword becomes valid. Observe the
 following example for building a Debian container from the Container
 Library:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: library
    From: debian:7
@@ -74,7 +74,7 @@ Library:
 A def file that uses an official mirror to install CentOS 7 might look
 like this:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: yum
    OSVersion: 7
@@ -124,7 +124,7 @@ If the bootstrap image is in the SIF format, then verification will be
 performed at build time. This verification checks whether the image has
 been signed. If it has been signed the integrity of the image is
 checked, and the signatures matched to public keys if available. This
-process is equivalent to running ``singularity verify`` on the bootstrap
+process is equivalent to running ``{command} verify`` on the bootstrap
 image.
 
 By default a failed verification, e.g. against an unsigned image, or one
@@ -134,7 +134,7 @@ build will continue.
 To enforce that the bootstrap image verifies correctly and has been
 signed by one or more keys, you can use the ``Fingerprints:`` header.
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: localimage
    From: test.sif
@@ -174,7 +174,7 @@ section (or any sections at all) within a def file. Furthermore,
 multiple sections of the same name can be included and will be appended
 to one another during the build process.
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: library
    From: ubuntu:18.04
@@ -243,7 +243,7 @@ has been installed. You can reference the container file system with the
 
 Consider the example from the definition file above:
 
-.. code:: singularity
+.. code:: {command}
 
    %setup
        touch /file1
@@ -266,7 +266,7 @@ system during the build, it's use is generally discouraged.
 The ``%files`` section allows you to copy files into the container with
 greater safety than using the ``%setup`` section. Its general form is:
 
-.. code:: singularity
+.. code:: {command}
 
    %files [from <stage>]
        <source> [<destination>]
@@ -283,7 +283,7 @@ while the ``<destination>`` is always a path into the current container. If the
 ``<source>``. To show how copying from your host system works, let's
 consider the example from the definition file above:
 
-.. code:: singularity
+.. code:: {command}
 
    %files
        /file1
@@ -297,7 +297,7 @@ container in ``/opt``.
 Files can also be copied from other stages by providing the source location in the
 previous stage and the destination in the current container.
 
-.. code:: singularity
+.. code:: {command}
 
    %files from stage_name
      /root/hello /bin/hello
@@ -329,7 +329,7 @@ write configuration files, create new directories, etc.
 
 Consider the example from the definition file above:
 
-.. code:: singularity
+.. code:: {command}
 
    %post
        apt-get update && apt-get install -y netcat
@@ -362,7 +362,7 @@ command.
 
 Consider the example from the def file above:
 
-.. code:: singularity
+.. code:: {command}
 
    %test
        grep -q NAME=\"Ubuntu\" /etc/os-release
@@ -383,14 +383,14 @@ build option:
 
 .. code::
 
-   $ sudo singularity build --notest my_container.sif my_container.def
+   $ sudo {command} build --notest my_container.sif my_container.def
 
 Running the test command on a container built with this def file yields
 the following:
 
 .. code::
 
-   $ singularity test my_container.sif
+   $ {command} test my_container.sif
    Container base is Ubuntu as expected.
 
 One common use of the ``%test`` section is to run a quick check that the
@@ -398,21 +398,21 @@ programs you intend to install in the container are present. If you
 installed the program ``samtools``, which shows a usage screen when run
 without any options, you might test it can be run with:
 
-.. code:: singularity
+.. code:: {command}
 
    %test
        # Run samtools - exits okay with usage screen if installed
        samtools
 
 If ``samtools`` is not successfully installed in the container then the
-``singularity test`` will exit with an error such as ``samtools: command
+``{command} test`` will exit with an error such as ``samtools: command
 not found``.
 
 Some programs return an error code when run without mandatory options.
 If you want to ignore this, and just check the program is present and
 can be called, you can run it as ``myprog || true`` in your test:
 
-.. code:: singularity
+.. code:: {command}
 
    %test
        # Run bwa - exits with error code if installed and run without
@@ -448,7 +448,7 @@ Specifically:
 You should use the same conventions that you would use in a ``.bashrc``
 or ``.profile`` file. Consider this example from the def file above:
 
-.. code:: singularity
+.. code:: {command}
 
    %environment
        export LISTEN_PORT=12345
@@ -463,7 +463,7 @@ variables are set appropriately at runtime with the following command:
 
 .. code::
 
-   $ singularity exec my_container.sif env | grep -E 'LISTEN_PORT|LC_ALL'
+   $ {command} exec my_container.sif env | grep -E 'LISTEN_PORT|LC_ALL'
    LISTEN_PORT=12345
    LC_ALL=C
 
@@ -471,7 +471,7 @@ To set a default value for a variable in the ``%environment`` section,
 but adopt the value of a host environment variable if it is set, use
 the following syntax:
 
-.. code:: singularity
+.. code:: {command}
 
     %environment
 	  FOO=${FOO:-'default'}
@@ -499,7 +499,7 @@ issued.
 
 Consider the example from the def file above.
 
-.. code:: singularity
+.. code:: {command}
 
    %startscript
        nc -lp $LISTEN_PORT
@@ -510,13 +510,13 @@ section above). The script can be invoked like so:
 
 .. code::
 
-   $ singularity instance start my_container.sif instance1
+   $ {command} instance start my_container.sif instance1
    INFO:    instance started successfully
 
    $ lsof | grep LISTEN
    nc        19061               vagrant    3u     IPv4             107409      0t0        TCP *:12345 (LISTEN)
 
-   $ singularity instance stop instance1
+   $ {command} instance stop instance1
    Stopping instance1 instance of /home/vagrant/my_container.sif (PID=19035)
 
 .. _runscript:
@@ -526,14 +526,14 @@ section above). The script can be invoked like so:
 
 The contents of the ``%runscript`` section are written to a file within
 the container that is executed when the container image is run (either
-via the ``singularity run`` command or by executing the container
+via the ``{command} run`` command or by executing the container
 directly as a command). When the container is invoked, arguments
 following the container name are passed to the runscript. This means
 that you can (and should) process arguments within your runscript.
 
 Consider the example from the def file above:
 
-.. code:: singularity
+.. code:: {command}
 
    %runscript
        echo "Container was created $NOW"
@@ -573,7 +573,7 @@ format is a name-value pair.
 
 Consider the example from the def file above:
 
-.. code:: singularity
+.. code:: {command}
 
    %labels
        Author d@sylabs.io
@@ -594,7 +594,7 @@ the following command:
 
 .. code::
 
-   $ singularity inspect my_container.sif
+   $ {command} inspect my_container.sif
 
    {
      "Author": "d@sylabs.io",
@@ -605,8 +605,8 @@ the following command:
      "org.label-schema.usage": "/.singularity.d/runscript.help",
      "org.label-schema.usage.singularity.deffile.bootstrap": "library",
      "org.label-schema.usage.singularity.deffile.from": "ubuntu:18.04",
-     "org.label-schema.usage.singularity.runscript.help": "/.singularity.d/runscript.help",
-     "org.label-schema.usage.singularity.version": "3.0.1"
+     "org.label-schema.usage.{command}.runscript.help": "/.singularity.d/runscript.help",
+     "org.label-schema.usage.{command}.version": "3.0.1"
    }
 
 Some labels that are captured automatically from the build process. You
@@ -622,7 +622,7 @@ the ``run-help`` command.
 
 Consider the example from the def file above:
 
-.. code:: singularity
+.. code:: {command}
 
    %help
        This is a demo container used to illustrate a def file that uses all
@@ -632,7 +632,7 @@ After building the help can be displayed like so:
 
 .. code::
 
-   $ singularity run-help my_container.sif
+   $ {command} run-help my_container.sif
        This is a demo container used to illustrate a def file that uses all
        supported sections.
 
@@ -645,7 +645,7 @@ one environment can be used for compilation, then the resulting binary
 can be copied into a final environment. This allows a slimmer final
 image that does not require the entire development stack.
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: golang:1.12.3-alpine3.9
@@ -719,7 +719,7 @@ alongside any of the primary sections (i.e. ``%post``,``%runscript``,
 The following runscript demonstrates how to build 2 different apps into
 the same container using SCIF modules:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: ubuntu
@@ -779,7 +779,7 @@ To run a specific app within the container:
 
 .. code::
 
-   % singularity run --app foo my_container.sif
+   % {command} run --app foo my_container.sif
    RUNNING FOO
 
 The same environment variable, ``$SOFTWARE`` is defined for both apps in
@@ -789,10 +789,10 @@ variable changes depending on the app we specify:
 
 .. code::
 
-   $ singularity exec --app foo my_container.sif env | grep SOFTWARE
+   $ {command} exec --app foo my_container.sif env | grep SOFTWARE
    SOFTWARE=foo
 
-   $ singularity exec --app bar my_container.sif env | grep SOFTWARE
+   $ {command} exec --app bar my_container.sif env | grep SOFTWARE
    SOFTWARE=bar
 
 **********************************

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -605,8 +605,8 @@ the following command:
      "org.label-schema.usage": "/.singularity.d/runscript.help",
      "org.label-schema.usage.singularity.deffile.bootstrap": "library",
      "org.label-schema.usage.singularity.deffile.from": "ubuntu:18.04",
-     "org.label-schema.usage.{command}.runscript.help": "/.singularity.d/runscript.help",
-     "org.label-schema.usage.{command}.version": "3.0.1"
+     "org.label-schema.usage.singularity.runscript.help": "/.singularity.d/runscript.help",
+     "org.label-schema.usage.singularity.version": "3.0.1"
    }
 
 Some labels that are captured automatically from the build process. You

--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -1,4 +1,4 @@
-.. _{command}-and-docker:
+.. _docker-and-oci:
 
 #######################################
  Support for Docker and OCI Containers
@@ -1120,7 +1120,7 @@ The table below gives a quick reference comparing Dockerfile and
 
 
 ================ =========================== ================ =============================
-{Project} Definition file                Dockerfile
+{Project}        Definition file             Dockerfile
 -------------------------------------------- ----------------------------------------------
 Section          Description                 Section          Description
 ================ =========================== ================ =============================
@@ -1163,7 +1163,7 @@ Section          Description                 Section          Description
 
 ``%runscript```  | Commands that will
                  | be run when you           ``ENTRYPOINT``   | Commands / arguments
-                 | ``{command} run``       ``CMD``          | that will run in the
+                 | ``{command} run``         ``CMD``          | that will run in the
                  | the container image.                       | container image.
 
 ``%startscript`` | Commands that will

--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -781,12 +781,12 @@ For example, the ``docker://openjdk:latest`` container sets ``JAVA_HOME``:
 
    # Check JAVA_HOME in the docker container.
    # This value comes from ENV in the Dockerfile.
-   $ singularity run docker://openjdk:latest echo \$JAVA_HOME
+   $ {command} run docker://openjdk:latest echo \$JAVA_HOME
    /usr/java/openjdk-17
 
    # Override JAVA_HOME in the container
    export APPTAINERENV_JAVA_HOME=/test
-   $ singularity run docker://openjdk:latest echo \$JAVA_HOME
+   $ {command} run docker://openjdk:latest echo \$JAVA_HOME
    /test
 
 Namespace & Device Isolation

--- a/encryption.rst
+++ b/encryption.rst
@@ -37,7 +37,7 @@ or a PEM file containing an asymmetric RSA public key. Of these two
 methods the PEM file is more secure and is therefore recommended for
 production use.
 
-An ``-e|--encrypt`` flag to ``singularity build`` is used to indicate
+An ``-e|--encrypt`` flag to ``{command} build`` is used to indicate
 that the container needs to be encrypted.
 
 A passphrase or a key-file used to perform the encryption is supplied at
@@ -80,7 +80,7 @@ Encrypting with a passphrase interactively
 
 .. code::
 
-   $ sudo singularity build --passphrase encrypted.sif encrypted.def
+   $ sudo {command} build --passphrase encrypted.sif encrypted.def
    Enter encryption passphrase: <secret>
    INFO:    Starting build...
 
@@ -89,7 +89,7 @@ Using an environment variable
 
 .. code::
 
-   $ sudo APPTAINER_ENCRYPTION_PASSPHRASE=<secret> singularity build --encrypt encrypted.sif encrypted.def
+   $ sudo APPTAINER_ENCRYPTION_PASSPHRASE=<secret> {command} build --encrypt encrypted.sif encrypted.def
    Starting build...
 
 In this case it is necessary to use the ``--encrypt`` flag since the
@@ -106,7 +106,7 @@ like so.
 
    $ export APPTAINER_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
 
-   $ sudo -E singularity build --encrypt encrypted.sif encrypted.def
+   $ sudo -E {command} build --encrypt encrypted.sif encrypted.def
    Starting build...
 
 PEM File Encryption
@@ -145,7 +145,7 @@ Encrypting with a command line option
 
 .. code::
 
-   $ sudo singularity build --pem-path=rsa_pub.pem encrypted.sif encrypted.def
+   $ sudo {command} build --pem-path=rsa_pub.pem encrypted.sif encrypted.def
    Starting build...
 
 Encrypting with an environment variable
@@ -153,7 +153,7 @@ Encrypting with an environment variable
 
 .. code::
 
-   $ sudo APPTAINER_ENCRYPTION_PEM_PATH=rsa_pub.pem singularity build --encrypt encrypted.sif encrypted.def
+   $ sudo APPTAINER_ENCRYPTION_PEM_PATH=rsa_pub.pem {command} build --encrypt encrypted.sif encrypted.def
    Starting build...
 
 In this case it is necessary to use the ``--encrypt`` flag since the
@@ -179,7 +179,7 @@ Running with a passphrase interactively
 
 .. code::
 
-   $ singularity run --passphrase encrypted.sif
+   $ {command} run --passphrase encrypted.sif
    Enter passphrase for encrypted container: <secret>
 
 Running with a passphrase in an environment variable
@@ -187,7 +187,7 @@ Running with a passphrase in an environment variable
 
 .. code::
 
-   $ APPTAINER_ENCRYPTION_PASSPHRASE="secret" singularity run encrypted.sif
+   $ APPTAINER_ENCRYPTION_PASSPHRASE="secret" {command} run encrypted.sif
 
 While this example shows how an environment variable can be used to set
 a passphrase, you should set the environment variable in a way that will
@@ -199,7 +199,7 @@ like so.
 
    $ export APPTAINER_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
 
-   $ singularity run encrypted.sif
+   $ {command} run encrypted.sif
 
 Running a container encrypted with a PEM file
 =============================================
@@ -212,11 +212,11 @@ Running using a command line option
 
 .. code::
 
-   $ singularity run --pem-path=rsa_pri.pem encrypted.sif
+   $ {command} run --pem-path=rsa_pri.pem encrypted.sif
 
 Running using an environment variable
 -------------------------------------
 
 .. code::
 
-   $ APPTAINER_ENCRYPTION_PEM_PATH=rsa_pri.pem singularity run encrypted.sif
+   $ APPTAINER_ENCRYPTION_PEM_PATH=rsa_pri.pem {command} run encrypted.sif

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -95,7 +95,7 @@ You can interact with the public Sylabs Cloud using various
 ***************************
 
 Users can setup and switch between multiple remote endpoints, which are
-stored in their ``~/.singularity/remote.yaml`` file. Alternatively,
+stored in their ``~/.{command}/remote.yaml`` file. Alternatively,
 remote endpoints can be set system-wide by an administrator.
 
 A remote endpoint may be the public Sylabs Cloud, a private installation
@@ -211,7 +211,7 @@ system) an administrative user should run:
 .. note::
 
    Global remote configurations can only be modified by the root user
-   and are stored in the ``etc/singularity/remote.yaml`` file, at the
+   and are stored in the ``etc/{command}/remote.yaml`` file, at the
    {Project} installation location.
 
 Conversely, to ``remove`` an endpoint:
@@ -411,7 +411,7 @@ before using it:
 
    $ {command} remote login --username ian https://pgp.example.com
    Password (or token when username is empty):
-   INFO:    Token stored in /home/ian/.singularity/remote.yaml
+   INFO:    Token stored in /home/ian/.{command}/remote.yaml
 
 Now we can see that ``https://pgp.example.com`` is logged in:
 
@@ -505,7 +505,7 @@ We can login to multiple OCI registries at the same time:
 
    $ {command} remote login --username ian docker://registry.example.com
    Password (or token when username is empty):
-   INFO:    Token stored in /home/ian/.singularity/remote.yaml
+   INFO:    Token stored in /home/ian/.{command}/remote.yaml
 
    $ {command} remote list
    Cloud Services Endpoints

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -27,7 +27,7 @@ Sylabs introduced the online `Sylabs Cloud
 A fresh, default installation of {Project} is configured to connect
 to the public `cloud.sylabs.io <https://cloud.sylabs.io>`__ services. If
 you only want to use the public services you just need to obtain an
-authentication token, and then ``singularity remote login``:
+authentication token, and then ``{command} remote login``:
 
    #. Go to: https://cloud.sylabs.io/
    #. Click "Sign In" and follow the sign in steps.
@@ -37,7 +37,7 @@ authentication token, and then ``singularity remote login``:
    #. Enter a name for your new access token, such as "test token"
    #. Click the "Create a New Access Token" button.
    #. Click "Copy token to Clipboard" from the "New API Token" page.
-   #. Run ``singularity remote login`` and paste the access token at the
+   #. Run ``{command} remote login`` and paste the access token at the
       prompt.
 
 Once your token is stored, you can check that you are able to connect to
@@ -45,7 +45,7 @@ the services with the ``status`` subcommand:
 
 .. code:: console
 
-   $ singularity remote status
+   $ {command} remote status
    INFO:    Checking status of default remote.
    SERVICE    STATUS  VERSION             URI
    Builder    OK      v1.1.14-0-gc7a68c1  https://build.sylabs.io
@@ -65,25 +65,25 @@ You can interact with the public Sylabs Cloud using various
 {Project} commands:
 
 `pull
-<cli/singularity_pull.html>`_,
+<cli/{command}_pull.html>`_,
 `push
-<cli/singularity_push.html>`_,
+<cli/{command}_push.html>`_,
 `build --remote
-<cli/singularity_build.html#options>`_,
+<cli/{command}_build.html#options>`_,
 `key
-<cli/singularity_key.html>`_,
+<cli/{command}_key.html>`_,
 `search
-<cli/singularity_search.html>`_,
+<cli/{command}_search.html>`_,
 `verify
-<cli/singularity_verify.html>`_,
+<cli/{command}_verify.html>`_,
 `exec
-<cli/singularity_exec.html>`_,
+<cli/{command}_exec.html>`_,
 `shell
-<cli/singularity_shell.html>`_,
+<cli/{command}_shell.html>`_,
 `run
-<cli/singularity_run.html>`_,
+<cli/{command}_run.html>`_,
 `instance
-<cli/singularity_instance.html>`_
+<cli/{command}_instance.html>`_
 
 .. note::
 
@@ -103,7 +103,7 @@ of Singularity Enterprise, or community-developed service that are API
 compatible.
 
 Generally, users and administrators should manage remote endpoints using
-the ``singularity remote`` command, and avoid editing ``remote.yaml``
+the ``{command} remote`` command, and avoid editing ``remote.yaml``
 configuration files directly.
 
 List and Login to Remotes
@@ -113,7 +113,7 @@ To ``list`` existing remote endpoints, run this:
 
 .. code::
 
-   $ singularity remote list
+   $ {command} remote list
 
    Cloud Services Endpoints
    ========================
@@ -136,14 +136,14 @@ was revoked:
 .. code:: console
 
    # Login to the default remote endpoint
-   $ singularity remote login
+   $ {command} remote login
 
    # Login to another remote endpoint
-   $ singularity remote login <remote_name>
+   $ {command} remote login <remote_name>
 
    # example...
-   $ singularity remote login SylabsCloud
-   singularity remote login SylabsCloud
+   $ {command} remote login SylabsCloud
+   {command} remote login SylabsCloud
    INFO:    Authenticating with remote: SylabsCloud
    Generate an API Key at https://cloud.sylabs.io/auth/tokens, and paste here:
    API Key:
@@ -156,7 +156,7 @@ existing token will not be replaced:
 
 .. code:: console
 
-   $ singularity remote login
+   $ {command} remote login
    An access token is already set for this remote. Replace it? [N/y]y
    Generate an access token at https://cloud.sylabs.io/auth/tokens, and paste it here.
    Token entered will be hidden for security.
@@ -178,14 +178,14 @@ To ``add`` a remote endpoint (for the current user only):
 
 .. code::
 
-   $ singularity remote add <remote_name> <remote_uri>
+   $ {command} remote add <remote_name> <remote_uri>
 
 For example, if you have an installation of {Project} enterprise
 hosted at enterprise.example.com:
 
 .. code::
 
-   $ singularity remote add myremote https://enterprise.example.com
+   $ {command} remote add myremote https://enterprise.example.com
 
    INFO:    Remote "myremote" added.
    INFO:    Authenticating with remote: myremote
@@ -200,11 +200,11 @@ system) an administrative user should run:
 
 .. code::
 
-   $ sudo singularity remote add --global <remote_name> <remote_uri>
+   $ sudo {command} remote add --global <remote_name> <remote_uri>
 
    # example..
 
-   $ sudo singularity remote add --global company-remote https://enterprise.example.com
+   $ sudo {command} remote add --global company-remote https://enterprise.example.com
    INFO:    Remote "company-remote" added.
    INFO:    Global option detected. Will not automatically log into remote.
 
@@ -218,14 +218,14 @@ Conversely, to ``remove`` an endpoint:
 
 .. code::
 
-   $ singularity remote remove <remote_name>
+   $ {command} remote remove <remote_name>
 
 Use the ``--global`` option as the root user to remove a global
 endpoint:
 
 .. code::
 
-   $ sudo singularity remote remove --global <remote_name>
+   $ sudo {command} remote remove --global <remote_name>
 
 Set the Default Remote
 ======================
@@ -235,14 +235,14 @@ A remote endpoint can be set as the default to use with commands such as
 
 .. code::
 
-   $ singularity remote use <remote_name>
+   $ {command} remote use <remote_name>
 
 The default remote shows up with a ``YES`` under the ``ACTIVE`` column
 in the output of ``remote list``:
 
 .. code::
 
-   $ singularity remote list
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -259,10 +259,10 @@ in the output of ``remote list``:
 
    * Active cloud services keyserver
 
-   $ singularity remote use myremote
+   $ {command} remote use myremote
    INFO:    Remote "myremote" now in use.
 
-   $ singularity remote list
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -285,9 +285,9 @@ remote the only usable remote for the system by using the
 
 .. code::
 
-   $ sudo singularity remote use --exclusive company-remote
+   $ sudo {command} remote use --exclusive company-remote
    INFO:    Remote "company-remote" now in use.
-   $ singularity remote list
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -308,7 +308,7 @@ This, in turn, prevents users from changing the remote they use:
 
 .. code::
 
-   $ singularity remote use myremote
+   $ {command} remote use myremote
    FATAL:   could not use myremote: remote company-remote has been set exclusive by the system administrator
 
 If you do not want to switch remote with ``remote use`` you can:
@@ -338,7 +338,7 @@ endpoint. We can also see the ``INSECURE`` column indicating that
 
 .. code::
 
-   $ singularity remote list
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -357,8 +357,8 @@ We can add a key server to list of keyservers with:
 
 .. code::
 
-   $ sudo singularity remote add-keyserver https://pgp.example.com
-   $ singularity remote list
+   $ sudo {command} remote add-keyserver https://pgp.example.com
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -380,8 +380,8 @@ that this key is placed, we can use the ``--order`` flag:
 
 .. code::
 
-   $ sudo singularity remote add-keyserver --order 1 https://pgp.example.com
-   $ singularity remote list
+   $ sudo {command} remote add-keyserver --order 1 https://pgp.example.com
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -409,7 +409,7 @@ before using it:
 
 .. code::
 
-   $ singularity remote login --username ian https://pgp.example.com
+   $ {command} remote login --username ian https://pgp.example.com
    Password (or token when username is empty):
    INFO:    Token stored in /home/ian/.singularity/remote.yaml
 
@@ -417,7 +417,7 @@ Now we can see that ``https://pgp.example.com`` is logged in:
 
 .. code::
 
-   $ singularity remote list
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -468,11 +468,11 @@ specifying a ``docker://`` prefix to the registry hostname:
 
 .. code::
 
-   $ singularity remote login --username ian docker://docker.io
+   $ {command} remote login --username ian docker://docker.io
    Password (or token when username is empty):
-   INFO:    Token stored in /home/ian/.singularity/remote.yaml
+   INFO:    Token stored in /home/ian/.{command}/remote.yaml
 
-   $ singularity remote list
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -503,11 +503,11 @@ We can login to multiple OCI registries at the same time:
 
 .. code::
 
-   $ singularity remote login --username ian docker://registry.example.com
+   $ {command} remote login --username ian docker://registry.example.com
    Password (or token when username is empty):
    INFO:    Token stored in /home/ian/.singularity/remote.yaml
 
-   $ singularity remote list
+   $ {command} remote list
    Cloud Services Endpoints
    ========================
 
@@ -534,20 +534,20 @@ off of the hostname when using the following commands with a
 ``docker://`` or ``oras://`` URI:
 
 `pull
-<cli/singularity_pull.html>`_,
+<cli/{command}_pull.html>`_,
 `push
-<cli/singularity_push.html>`_,
+<cli/{command}_push.html>`_,
 `build
-<cli/singularity_build.html>`_,
+<cli/{command}_build.html>`_,
 `exec
-<cli/singularity_exec.html>`_,
+<cli/{command}_exec.html>`_,
 `shell
-<cli/singularity_shell.html>`_,
+<cli/{command}_shell.html>`_,
 `run
-<cli/singularity_run.html>`_,
+<cli/{command}_run.html>`_,
 `instance
-<cli/singularity_instance.html>`_
-
+<cli/{command}_instance.html>`_
+1
 .. note::
 
    It is important for users to be aware that the login command will

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -75,13 +75,13 @@ environment variables will be set. If you are using a ``library`` or
 ``Docker`` source then you may inherit environment variables from your
 base image.
 
-If I build a singularity container from the image
+If I build a {command} container from the image
 ``docker://python:3.7`` then when I run the container I can see that the
 ``PYTHON_VERSION`` variable is set in the container:
 
 .. code::
 
-   $ singularity exec python.sif env | grep PYTHON_VERSION
+   $ {command} exec python.sif env | grep PYTHON_VERSION
    PYTHON_VERSION=3.7.7
 
 This happens because the ``Dockerfile`` used to build that container has
@@ -99,7 +99,7 @@ Environment variables can be included in your container by adding them
 to your definition file. Use ``export`` in the ``%environment`` section
 of a definition file to set a container environment variable:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: library
    From: default/alpine
@@ -115,7 +115,7 @@ The ``%runscript`` is set to echo the value.
 
 .. code::
 
-   $ singularity run env.sif
+   $ {command} run env.sif
    Hello
 
 .. warning::
@@ -185,7 +185,7 @@ environment variables for correct operation of most software.
 
 .. code::
 
-   $ singularity exec --cleanenv env.sif env
+   $ {command} exec --cleanenv env.sif env
    HOME=/home/dave
    LANG=C
    LD_LIBRARY_PATH=/.singularity.d/libs
@@ -251,10 +251,10 @@ specify environment variables as ``NAME=VALUE`` pairs:
 
 .. code::
 
-   $ singularity run env.sif
+   $ {command} run env.sif
    Hello
 
-   $ singularity run --env MYVAR=Goodbye env.sif
+   $ {command} run --env MYVAR=Goodbye env.sif
    Goodbye
 
 Separate multiple variables with commas, e.g. ``--env
@@ -272,7 +272,7 @@ environment variables as ``NAME=VALUE`` pairs, e.g.:
    $ cat myenvs
    MYVAR="Hello from a file"
 
-   $ singularity run --env-file myenvs env.sif
+   $ {command} run --env-file myenvs env.sif
    Hello from a file
 
 ``APPTAINERENV_`` prefix
@@ -284,11 +284,11 @@ the environment variable ``xxx`` inside the container:
 
 .. code::
 
-   $ singularity run env.sif
+   $ {command} run env.sif
    Hello
 
    $ export APPTAINERENV_MYVAR="Overridden"
-   $ singularity run env.sif
+   $ {command} run env.sif
    Overridden
 
 Manipulating ``PATH``
@@ -330,11 +330,11 @@ variable in the container.
 
 .. code::
 
-   $ singularity exec env.sif sh -c 'echo $PATH'
+   $ {command} exec env.sif sh -c 'echo $PATH'
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
    $ export APPTAINERENV_APPEND_PATH="/endpath"
-   $ singularity exec env.sif sh -c 'echo $PATH'
+   $ {command} exec env.sif sh -c 'echo $PATH'
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/endpath
 
 Alternatively you could use the ``--env`` option to set a
@@ -346,11 +346,11 @@ to the start) of the ``PATH`` variable in the container.
 
 .. code::
 
-   $ singularity exec env.sif sh -c 'echo $PATH'
+   $ {command} exec env.sif sh -c 'echo $PATH'
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
    $ export APPTAINERENV_PREPEND_PATH="/startpath"
-   $ singularity exec env.sif sh -c 'echo $PATH'
+   $ {command} exec env.sif sh -c 'echo $PATH'
    /startpath:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 Alternatively you could use the ``--env`` option to set a
@@ -382,11 +382,11 @@ processed by the host shell before the value is passed to
 
 .. code::
 
-   singularity run --env "MYHOST=$HOSTNAME" mycontainer.sif
+   {command} run --env "MYHOST=$HOSTNAME" mycontainer.sif
 
 This will set the ``MYHOST`` environment variable inside the container
 to the value of the ``HOSTNAME`` on the host system. ``$HOSTNAME`` is
-substituted before the host shell runs ``singularity``.
+substituted before the host shell runs ``{command}``.
 
 .. note::
 
@@ -407,7 +407,7 @@ same value as ``PATH`` in the container (not the host's ``PATH``):
 
 .. code::
 
-   singularity run --env "MYPATH=\$PATH" mycontainer.sif
+   {command} run --env "MYPATH=\$PATH" mycontainer.sif
 
 You can also use this approach to append or prepend to variables that
 are already set in the container. For example, ``--env
@@ -425,7 +425,7 @@ you need to set a path containing a literal ``$LIB`` for the
 
 .. code::
 
-   singularity run --env="LD_PRELOAD=/foo/bar/\\\$LIB/baz.so" mycontainer.sif
+   {command} run --env="LD_PRELOAD=/foo/bar/\\\$LIB/baz.so" mycontainer.sif
 
 This will result in ``LD_PRELOAD`` having the value
 ``/foo/bar/$LIB/baz.so`` inside the container.
@@ -439,7 +439,7 @@ level of escaping:
 
 .. code::
 
-   singularity run --env='LD_PRELOAD=/foo/bar/\$LIB/baz.so' mycontainer.sif
+   {command} run --env='LD_PRELOAD=/foo/bar/\$LIB/baz.so' mycontainer.sif
 
 
 Environment Variable Precedence
@@ -546,7 +546,7 @@ it is not modifying an existing label when ``--force`` is not used:
 
 .. code::
 
-   $ singularity build test2.sif test2.def
+   $ {command} build test2.sif test2.def
    ...
    INFO:    Adding labels
    WARNING: Label: OWNER already exists and force option is false, not overwriting
@@ -562,7 +562,7 @@ Custom Labels
 You can add custom labels to your container using the ``%labels``
 section in a definition file:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: library
    From: ubuntu:latest
@@ -582,7 +582,7 @@ building.
 file defined by the ``APPTAINER_LABELS`` environment variable in the
 ``%post`` section:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: library
    From: ubuntu:latest
@@ -615,7 +615,7 @@ options will display any labels set on the container
 
 .. code:: console
 
-   $ singularity inspect ubuntu.sif
+   $ {command} inspect ubuntu.sif
    my.label: version 1.2.3
    OWNER: Joana
    org.label-schema.build-arch: amd64
@@ -623,7 +623,7 @@ options will display any labels set on the container
    org.label-schema.schema-version: 1.0
    org.label-schema.usage.singularity.deffile.bootstrap: library
    org.label-schema.usage.singularity.deffile.from: ubuntu:latest
-   org.label-schema.usage.singularity.version: 3.7.0-rc.1
+   org.label-schema.usage.{command}.version: 3.7.0-rc.1
 
 We can easily see when the container was built, the source of the base
 image, and the exact version of {Project} that was used to build it.
@@ -639,11 +639,11 @@ used to build the container.
 
 .. code::
 
-   $ singularity inspect --deffile jupyter.sif
+   $ {command} inspect --deffile jupyter.sif
 
 And the output would look like:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: library
    From: debian:9
@@ -710,7 +710,7 @@ The ``-r`` or ``--runscript`` option shows the runscript for the image.
 
 .. code::
 
-   $ singularity inspect --runscript jupyter.sif
+   $ {command} inspect --runscript jupyter.sif
 
 And the output would look like:
 
@@ -750,7 +750,7 @@ The ``-t`` or ``--test`` flag shows the test script for the image.
 
 .. code::
 
-   $ singularity inspect --test jupyter.sif
+   $ {command} inspect --test jupyter.sif
 
 This will output the corresponding ``%test`` section from the definition
 file.
@@ -764,7 +764,7 @@ more environment files, depending on how the container was built.
 
 .. code::
 
-   $ singularity inspect --environment jupyter.sif
+   $ {command} inspect --environment jupyter.sif
 
 And the output would look like:
 
@@ -787,7 +787,7 @@ You can call it this way:
 
 .. code::
 
-   $ singularity inspect --helpfile jupyter.sif
+   $ {command} inspect --helpfile jupyter.sif
 
 And the output would look like:
 
@@ -806,7 +806,7 @@ You can call it this way:
 
 .. code:: console
 
-   $ singularity inspect --json ubuntu.sif
+   $ {command} inspect --json ubuntu.sif
 
 And the output would look like:
 
@@ -823,7 +823,7 @@ And the output would look like:
                                    "org.label-schema.schema-version": "1.0",
                                    "org.label-schema.usage.singularity.deffile.bootstrap": "library",
                                    "org.label-schema.usage.singularity.deffile.from": "ubuntu:latest",
-                                   "org.label-schema.usage.singularity.version": "3.7.0-rc.1"
+                                   "org.label-schema.usage.{command}.version": "3.7.0-rc.1"
                            }
                    }
            },
@@ -856,7 +856,7 @@ SIF file metadata descriptor.
    │   └── test
    ├── env
    │   ├── 01-base.sh
-   |   ├── 10-docker2singularity.sh
+   |   ├── 10-docker2{command}.sh
    │   ├── 90-environment.sh
    │   ├── 91-environment.sh
    |   ├── 94-appsbase.sh
@@ -895,7 +895,7 @@ SIF file metadata descriptor.
 -  **runscript**: The commands in this file will be executed when the
    container is invoked with the ``run`` command or called as an
    executable. For legacy purposes there is a symbolic link called
-   ``/singularity`` that points to this file.
+   ``/{command}`` that points to this file.
 
 -  **runscript.help**: Contains the description that was added in the
    ``%help`` section.

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -173,10 +173,10 @@ the host:
 .. code::
 
    $ export APPTAINERENV_MYVAR="$MYVAR"
-   $ singularity run mycontainer.sif
+   $ {command} run mycontainer.sif
 
    # or
-   $ singularity run --env "MYVAR=$MYVAR"
+   $ {command} run --env "MYVAR=$MYVAR"
 
 If you *do not want* the host environment variables to pass into the
 container you can use the ``-e`` or ``--cleanenv`` option. This gives a
@@ -623,7 +623,7 @@ options will display any labels set on the container
    org.label-schema.schema-version: 1.0
    org.label-schema.usage.singularity.deffile.bootstrap: library
    org.label-schema.usage.singularity.deffile.from: ubuntu:latest
-   org.label-schema.usage.{command}.version: 3.7.0-rc.1
+   org.label-schema.usage.singularity.version: 3.7.0-rc.1
 
 We can easily see when the container was built, the source of the base
 image, and the exact version of {Project} that was used to build it.
@@ -823,7 +823,7 @@ And the output would look like:
                                    "org.label-schema.schema-version": "1.0",
                                    "org.label-schema.usage.singularity.deffile.bootstrap": "library",
                                    "org.label-schema.usage.singularity.deffile.from": "ubuntu:latest",
-                                   "org.label-schema.usage.{command}.version": "3.7.0-rc.1"
+                                   "org.label-schema.usage.singularity.version": "3.7.0-rc.1"
                            }
                    }
            },
@@ -856,7 +856,7 @@ SIF file metadata descriptor.
    │   └── test
    ├── env
    │   ├── 01-base.sh
-   |   ├── 10-docker2{command}.sh
+   |   ├── 10-docker2singularity.sh
    │   ├── 90-environment.sh
    │   ├── 91-environment.sh
    |   ├── 94-appsbase.sh
@@ -895,7 +895,7 @@ SIF file metadata descriptor.
 -  **runscript**: The commands in this file will be executed when the
    container is invoked with the ``run`` command or called as an
    executable. For legacy purposes there is a symbolic link called
-   ``/{command}`` that points to this file.
+   ``/singularity`` that points to this file.
 
 -  **runscript.help**: Contains the description that was added in the
    ``%help`` section.

--- a/fakeroot.rst
+++ b/fakeroot.rst
@@ -69,7 +69,7 @@ system.
 Network
 =======
 
-Restrictions are also applied to networking, if ``singularity`` is
+Restrictions are also applied to networking, if ``{command}`` is
 executed without the ``--net`` flag, the **"fake root"** user won't be
 able to use ``ping`` or bind a container service to a port below 1024.
 
@@ -87,7 +87,7 @@ the host network.
 .. warning::
 
    For unprivileged installation of {Project} or if ``allow setuid =
-   no`` is set in ``singularity.conf`` users won't be able to use a
+   no`` is set in ``{command}.conf`` users won't be able to use a
    ``fakeroot`` network.
 
 ******************************
@@ -99,7 +99,7 @@ mappings in ``/etc/subgid``, so your username needs to be listed in
 those files with a valid mapping (see the admin-guide for details), if
 you can't edit the files ask an administrator.
 
-{Project} provides a ``singularity config fakeroot`` command 
+{Project} provides a ``{command} config fakeroot`` command 
 to allow configuration of the ``/etc/subuid`` and
 ``/etc/subgid`` mappings from the {Project} command line. You must
 be a root user or run with ``sudo`` to use ``config fakeroot``, as the
@@ -114,7 +114,7 @@ If your user account is configured with valid ``subuid`` and ``subgid``
 mappings you work as a fake root user inside a container by using the
 ``--fakeroot`` or ``-f`` option.
 
-The ``--fakeroot`` option is available with the following singularity
+The ``--fakeroot`` option is available with the following {command}
 commands:
 
    -  ``shell``
@@ -142,18 +142,18 @@ Build from a definition file:
 
 .. code::
 
-   singularity build --fakeroot /tmp/test.sif /tmp/test.def
+   {command} build --fakeroot /tmp/test.sif /tmp/test.def
 
 Ping from container:
 --------------------
 
 .. code::
 
-   singularity exec --fakeroot --net docker://alpine ping -c1 8.8.8.8
+   {command} exec --fakeroot --net docker://alpine ping -c1 8.8.8.8
 
 HTTP server:
 ------------
 
 .. code::
 
-   singularity run --fakeroot --net --network-args="portmap=8080:80/tcp" -w docker://nginx
+   {command} run --fakeroot --net --network-args="portmap=8080:80/tcp" -w docker://nginx

--- a/gpu.rst
+++ b/gpu.rst
@@ -66,7 +66,7 @@ compiled for the latest versions of CUDA.
 
 {Project} will find the NVIDIA/CUDA libraries on your host using the
 list of libraries in the configuration file
-``etc/singularity/nvbliblist``, and resolving paths through the
+``etc/{command}/nvbliblist``, and resolving paths through the
 ``ldconfig`` cache. At time of release this list is appropriate for the
 latest stable CUDA version. It can be modified by the administrator to
 add additional libraries if necessary. See the admin guide for more

--- a/gpu.rst
+++ b/gpu.rst
@@ -90,7 +90,7 @@ to a SIF before you start working with it:
 
 .. code::
 
-   $ singularity pull docker://tensorflow/tensorflow:latest-gpu
+   $ {command} pull docker://tensorflow/tensorflow:latest-gpu
    ...
    INFO:    Creating SIF file...
    INFO:    Build complete: tensorflow_latest-gpu.sif
@@ -99,7 +99,7 @@ Then run the container with GPU support:
 
 .. code::
 
-   $ singularity run --nv tensorflow_latest-gpu.sif
+   $ {command} run --nv tensorflow_latest-gpu.sif
 
    ________                               _______________
    ___  __/__________________________________  ____/__  /________      __
@@ -161,12 +161,12 @@ the host, we could do:
 
 .. code::
 
-   $ APPTAINERENV_CUDA_VISIBLE_DEVICES=0 singularity run --nv tensorflow_latest-gpu.sif
+   $ APPTAINERENV_CUDA_VISIBLE_DEVICES=0 {command} run --nv tensorflow_latest-gpu.sif
 
    # or
 
    $ export APPTAINERENV_CUDA_VISIBLE_DEVICES=0
-   $ singularity run tensorflow_latest-gpu.sif
+   $ {command} run tensorflow_latest-gpu.sif
 
 Troubleshooting
 ===============
@@ -223,7 +223,7 @@ Requirements & Limitations
 ==========================
 
 -  ``nvidia-container-cli`` must be installed on your host. Its path must
-   be set in ``singularity.conf``. This value will be set at build time if
+   be set in ``{command}.conf``. This value will be set at build time if
    ``nvidia-container-cli`` is found on the search ``$PATH``.
 
 -  For security reasons, ``--nvccli`` cannot be used with
@@ -249,7 +249,7 @@ large container into a sandbox:
 
 .. code::
 
-   $ singularity build --sandbox tensorflow_latest-gpu docker://tensorflow/tensorflow:latest-gpu
+   $ {command} build --sandbox tensorflow_latest-gpu docker://tensorflow/tensorflow:latest-gpu
    INFO:    Starting build...
    ...
    INFO:    Creating sandbox directory...
@@ -259,7 +259,7 @@ Then run the container with ``nvidia-container-cli`` GPU support:
 
 .. code::
 
-   $ singularity run -uw --nv --nvccli tensorflow_latest-gpu
+   $ {command} run -uw --nv --nvccli tensorflow_latest-gpu
 
    ________                               _______________
    ___  __/__________________________________  ____/__  /________      __
@@ -316,7 +316,7 @@ on a system with 4 GPUs, run the following:
 .. code::
 
    $ export NVIDIA_VISIBLE_DEVICES=1,2
-   $ singularity run -uwc --nv --nvccli tensorflow_latest-gpu
+   $ {command} run -uwc --nv --nvccli tensorflow_latest-gpu
 
 Note that:
 
@@ -338,7 +338,7 @@ GPUs will be available in the container, and a warning will be shown:
 
 .. code::
 
-   $ singularity run -uwc --nv --nvccli tensorflow_latest-gpu
+   $ {command} run -uwc --nv --nvccli tensorflow_latest-gpu
    WARNING: When using nvidia-container-cli with --contain NVIDIA_VISIBLE_DEVICES
    must be set or no GPUs will be available in container.
 
@@ -362,7 +362,7 @@ Other GPU Options
 
 In ``--nvccli`` mode, {Project} understands the following additional
 environment variables. Note that these environment variables are read
-from the environment where ``singularity`` is run. {Project} does
+from the environment where ``{command}`` is run. {Project} does
 not currently read these settings from the container environment.
 
 -  ``NVIDIA_DRIVER_CAPABILITIES`` controls which libraries and utilities
@@ -452,7 +452,7 @@ to a SIF before you start working with it:
 
 .. code::
 
-   $ singularity pull docker://rocm/tensorflow:latest
+   $ {command} pull docker://rocm/tensorflow:latest
    ...
    INFO:    Creating SIF file...
    INFO:    Build complete: tensorflow_latest.sif
@@ -461,7 +461,7 @@ Then run the container with GPU support:
 
 .. code::
 
-   $ singularity run --rocm tensorflow_latest.sif
+   $ {command} run --rocm tensorflow_latest.sif
 
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
@@ -511,7 +511,7 @@ the Sylabs library:
 
 .. code::
 
-   $ singularity exec --rocm --bind /etc/OpenCL library://sylabs/examples/blender blender
+   $ {command} exec --rocm --bind /etc/OpenCL library://sylabs/examples/blender blender
 
 Note the *exec* used as the *runscript* for this container is setup for
 batch rendering (which can also use OpenCL).

--- a/index.rst
+++ b/index.rst
@@ -100,7 +100,7 @@ Docker, as well as how to use containerized MPI and GPU applications.
 .. toctree::
    :maxdepth: 1
 
-   Support for Docker / OCI Containers <singularity_and_docker>
+   Support for Docker / OCI Containers <docker_and_oci>
    OCI Runtime Support <oci_runtime>
    {Project} and MPI applications <mpi>
    GPU Support <gpu>

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -52,7 +52,7 @@ The output will look as it follows:
 
 .. code:: {command}
 
-   Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
+   Private key listing (/home/joana/.{command}/sypgp/pgp-secret):
 
    0) U: Johnny Cash (none) <cash@sylabs.io>
    C: 2019-04-11 22:22:28 +0200 CEST
@@ -101,7 +101,7 @@ keystore by running ``{command} key list -s`` command:
 
 .. code:: {command}
 
-   Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
+   Private key listing (/home/joana/.{command}/sypgp/pgp-secret):
 
      0) U: Johnny Cash (none) <cash@sylabs.io>
      C: 2019-04-11 22:22:28 +0200 CEST

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -39,9 +39,9 @@ keystore.
 First we will check what's the status of the local keystore (which keys
 are stored by the moment before importing a new key).
 
-.. code:: singularity
+.. code:: {command}
 
-   $ singularity key list --secret
+   $ {command} key list --secret
 
 .. note::
 
@@ -50,7 +50,7 @@ are stored by the moment before importing a new key).
 
 The output will look as it follows:
 
-.. code:: singularity
+.. code:: {command}
 
    Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
 
@@ -76,9 +76,9 @@ location to the file, let's say you own a gpg key file named
 ``pinkie-pie.asc`` which is a secret GPG key you want to import. Then
 you will just need to run the following command to import your key:
 
-.. code:: singularity
+.. code:: {command}
 
-   $ singularity key import $HOME/pinkie-pie.asc
+   $ {command} key import $HOME/pinkie-pie.asc
 
 .. note::
 
@@ -89,7 +89,7 @@ Since you're importing a private (secret) key, you will need to specify
 the passphrase related to it and then a new passphrase to be added on
 your local keystore.
 
-.. code:: singularity
+.. code:: {command}
 
    Enter your old password :
    Enter a new password for this key :
@@ -97,9 +97,9 @@ your local keystore.
    Key with fingerprint 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 successfully added to the keyring
 
 After this you can see if that key was correctly added to your local
-keystore by running ``singularity key list -s`` command:
+keystore by running ``{command} key list -s`` command:
 
-.. code:: singularity
+.. code:: {command}
 
    Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
 
@@ -143,32 +143,32 @@ import`` command.
 
 For example to export a public key in binary format you can run:
 
-.. code:: singularity
+.. code:: {command}
 
-   $ singularity key export 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+   $ {command} key export 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 This will export a public binary key named ``mykey.asc`` and will save
 it under the home folder. If you would like to export the same public
 key but in an ``ASCII`` armored format, you would need to run the
 following command:
 
-.. code:: singularity
+.. code:: {command}
 
-   $ singularity key export --armor 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+   $ {command} key export --armor 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 And in the case in which you may need to export a secret key on
 ``ASCII`` armored format, you would need to specify from where to find
 the key, since the fingerprint is the same.
 
-.. code:: singularity
+.. code:: {command}
 
-   $ singularity key export --armor --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+   $ {command} key export --armor --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 and on binary format instead:
 
-.. code:: singularity
+.. code:: {command}
 
-   $ singularity key export --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+   $ {command} key export --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 .. note::
 
@@ -185,9 +185,9 @@ and on binary format instead:
 In case you would want to remove a public key from your public local
 keystore, you can do so by running the following command:
 
-.. code:: singularity
+.. code:: {command}
 
-   $ singularity key remove 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
+   $ {command} key remove 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
 
 .. note::
 

--- a/mpi.rst
+++ b/mpi.rst
@@ -40,7 +40,7 @@ host into the container.
 
 The basic idea behind the *Hybrid Approach* is when you execute a
 {Project} container with MPI code, you will call ``mpiexec`` or a
-similar launcher on the ``singularity`` command itself. The MPI process
+similar launcher on the ``{command}`` command itself. The MPI process
 outside of the container will then work in tandem with MPI inside the
 container and the containerized MPI code to instantiate the job.
 
@@ -259,7 +259,7 @@ container has been built based on the hybrid model:
 
 .. code::
 
-   $ mpirun -n <NUMBER_OF_RANKS> singularity exec <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
+   $ mpirun -n <NUMBER_OF_RANKS> {command} exec <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
 
 Practically, this command will first start a process instantiating
 ``mpirun`` and then {Project} containers on compute nodes. Finally,
@@ -267,7 +267,7 @@ when the containers start, the MPI binary is executed:
 
 .. code::
 
-   $ mpirun -n 8 singularity run hybrid-mpich.sif /opt/mpitest
+   $ mpirun -n 8 {command} run hybrid-mpich.sif /opt/mpitest
    Hello, I am rank 3/8
    Hello, I am rank 4/8
    Hello, I am rank 6/8
@@ -374,7 +374,7 @@ definition file if you wish.
 .. code::
 
    $ export MPI_DIR="<PATH/TO/HOST/MPI/DIRECTORY>"
-   $ mpirun -n <NUMBER_OF_RANKS> singularity exec --bind "$MPI_DIR" <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
+   $ mpirun -n <NUMBER_OF_RANKS> {command} exec --bind "$MPI_DIR" <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
 
 On an example system we may be using an Open MPI installation at
 ``/cm/shared/apps/openmpi/gcc/64/4.0.5/``. This means that the commands
@@ -383,7 +383,7 @@ to run the container in bind mode are:
 .. code::
 
    $ export MPI_DIR="/cm/shared/apps/openmpi/gcc/64/4.0.5"
-   $ mpirun -n 8 singularity exec --bind "$MPI_DIR" bind.sif /opt/mpitest
+   $ mpirun -n 8 {command} exec --bind "$MPI_DIR" bind.sif /opt/mpitest
    Hello, I am rank 1/8
    Hello, I am rank 2/8
    Hello, I am rank 0/8
@@ -408,11 +408,11 @@ batch systems available.
 
    $ cat my_job.sh
    #!/bin/bash
-   #SBATCH --job-name singularity-mpi
+   #SBATCH --job-name {command}-mpi
    #SBATCH -N $NNODES # total number of nodes
    #SBATCH --time=00:05:00 # Max execution time
 
-   mpirun -n $NP singularity exec /var/nfsshare/gvallee/mpich.sif /opt/mpitest
+   mpirun -n $NP {command} exec /var/nfsshare/gvallee/mpich.sif /opt/mpitest
 
 In fact, the example describes a job that requests the number of nodes
 specified by the ``NNODES`` environment variable and a total number of
@@ -470,7 +470,7 @@ E.g. if we attempt to run the hybrid Open MPI container, but with
 .. code::
 
    $ module add mpich
-   $ mpirun -n 8 singularity run hybrid-openmpi.sif /opt/mpitest
+   $ mpirun -n 8 {command} run hybrid-openmpi.sif /opt/mpitest
    Hello, I am rank 0/1
    Hello, I am rank 0/1
    Hello, I am rank 0/1

--- a/networking.rst
+++ b/networking.rst
@@ -21,7 +21,7 @@ configure a virtualized network for a container.
    {Project} allows the administrator to permit a list of
    unprivileged users and/or groups to use specified network
    configurations. This is accomplished through settings in
-   ``singularity.conf``. See the administrator guide for details.
+   ``{command}.conf``. See the administrator guide for details.
 
 ***********
  ``--dns``
@@ -35,10 +35,10 @@ servers to add to the ``/etc/resolv.conf`` file.
    $ nslookup sylabs.io | grep Server
    Server:             127.0.0.53
 
-   $ sudo singularity exec --dns 8.8.8.8 ubuntu.sif nslookup sylabs.io | grep Server
+   $ sudo {command} exec --dns 8.8.8.8 ubuntu.sif nslookup sylabs.io | grep Server
    Server:             8.8.8.8
 
-   $ sudo singularity exec --dns 8.8.8.8 ubuntu.sif cat /etc/resolv.conf
+   $ sudo {command} exec --dns 8.8.8.8 ubuntu.sif cat /etc/resolv.conf
    nameserver 8.8.8.8
 
 ****************
@@ -53,7 +53,7 @@ hostname within the container.
    $ hostname
    ubuntu-bionic
 
-   $ sudo singularity exec --hostname hal-9000 my_container.sif hostname
+   $ sudo {command} exec --hostname hal-9000 my_container.sif hostname
    hal-9000
 
 ***********
@@ -69,7 +69,7 @@ interface will also be set up by default.
    $ hostname -I
    10.0.2.15
 
-   $ sudo singularity exec --net my_container.sif hostname -I
+   $ sudo {command} exec --net my_container.sif hostname -I
    10.22.0.4
 
 ***************
@@ -85,15 +85,15 @@ Each entry will bring up a dedicated interface inside container.
    $ hostname -I
    172.16.107.251 10.22.0.1
 
-   $ sudo singularity exec --net --network ptp ubuntu.sif hostname -I
+   $ sudo {command} exec --net --network ptp ubuntu.sif hostname -I
    10.23.0.6
 
-   $ sudo singularity exec --net --network bridge,ptp ubuntu.sif hostname -I
+   $ sudo {command} exec --net --network bridge,ptp ubuntu.sif hostname -I
    10.22.0.14 10.23.0.7
 
-When invoked, the ``--network`` option searches the singularity
+When invoked, the ``--network`` option searches the {command}
 configuration directory (commonly
-``/usr/local/etc/singularity/network/``) for the cni configuration file
+``/usr/local/etc/{command}/network/``) for the cni configuration file
 corresponding to the requested network type(s). Several configuration
 files are installed with {Project} by default corresponding to the
 following network types:
@@ -109,7 +109,7 @@ by non-privileged users. It isolates the container network from the host
 network with a loopback interface.
 
 Administrators can permit certain users or groups to request other
-network configurations through options in ``singularity.conf``.
+network configurations through options in ``{command}.conf``.
 Additional cni configuration files can be added to the ``network``
 configuration directory as required, and {Project}'s provided
 configurations may also be modified.
@@ -128,7 +128,7 @@ but you want to map it to port 8080 outside of the container:
 
 .. code::
 
-   $ sudo singularity instance start --writable-tmpfs \
+   $ sudo {command} instance start --writable-tmpfs \
        --net --network-args "portmap=8080:80/tcp" docker://nginx web2
 
 The above command will start the Docker Hub official NGINX image running
@@ -143,7 +143,7 @@ Now we can start NGINX inside of the container:
 
 .. code::
 
-   $ sudo singularity exec instance://web2 nginx
+   $ sudo {command} exec instance://web2 nginx
 
 And the ``curl`` command can be used to verify that NGINX is running on
 the host port 8080 as expected.

--- a/oci_runtime.rst
+++ b/oci_runtime.rst
@@ -53,7 +53,7 @@ exists locally. (Recall:
 
 .. code::
 
-   $ singularity pull docker://busybox
+   $ {command} pull docker://busybox
    INFO:    Starting build...
    Getting image source signatures
    Copying blob sha256:fc1a6b909f82ce4b72204198d49de3aaf757b3ab2bb823cb6e47c416b97c5985
@@ -76,7 +76,7 @@ container, this SIF file can be mounted as follows:
 
 .. code::
 
-   $ sudo singularity oci mount ./busybox_latest.sif /var/tmp/busybox
+   $ sudo {command} oci mount ./busybox_latest.sif /var/tmp/busybox
 
 By issuing the ``mount`` command, the root filesystem encapsulated in
 the SIF file ``busybox_latest.sif`` is mounted on ``/var/tmp/busybox``
@@ -735,11 +735,11 @@ filesystem, as required by the standard; this filesystem has contents:
 .. code::
 
    $ sudo ls /var/tmp/busybox/rootfs
-   bin  dev  environment  etc  home  proc  root  singularity  sys  tmp  usr  var
+   bin  dev  environment  etc  home  proc  root  {command}  sys  tmp  usr  var
 
 .. note::
 
-   ``environment`` and ``singularity`` above are symbolic links to the
+   ``environment`` and ``{command}`` above are symbolic links to the
    ``.singularity.d`` directory.
 
 ..
@@ -800,16 +800,16 @@ as follows:
 
 .. code::
 
-   $ sudo singularity oci create -b /var/tmp/busybox busybox1
+   $ sudo {command} oci create -b /var/tmp/busybox busybox1
 
 .. note::
 
    Data for the ``config.json`` file exists within the SIF file as a
    descriptor for images pulled or built from Docker/OCI registries. For
    images sourced elsewhere, a default ``config.json`` file is created
-   when the ``singularity oci mount ...`` command is issued.
+   when the ``{command} oci mount ...`` command is issued.
 
-   Upon invocation, ``singularity oci mount ...`` also mounts the root
+   Upon invocation, ``{command} oci mount ...`` also mounts the root
    filesystem stored in the SIF file on ``/bundle/rootfs``, and
    establishes an overlay filesystem on the mount point
    ``/bundle/overlay``.
@@ -828,7 +828,7 @@ bootstrap process. The instance is named ``busybox1`` in this example.
    invocation requests.
 
 The ``state`` of the container instance can be determined via ``$ sudo
-singularity oci state busybox1``:
+{command} oci state busybox1``:
 
 .. code:: json
 
@@ -839,8 +839,8 @@ singularity oci state busybox1``:
    "pid": 6578,
    "bundle": "/var/tmp/busybox",
    "createdAt": 1554389921452964253,
-   "attachSocket": "/var/run/singularity/instances/root/busybox1/attach.sock",
-   "controlSocket": "/var/run/singularity/instances/root/busybox1/control.sock"
+   "attachSocket": "/var/run/{command}/instances/root/busybox1/attach.sock",
+   "controlSocket": "/var/run/{command}/instances/root/busybox1/control.sock"
    }
 
 Container state, as conveyed via these properties, is in compliance with
@@ -864,10 +864,10 @@ in deployments where auditing requirements exist.
    ------------------------------------------
 
 ..
-   $ sudo singularity oci start busybox
+   $ sudo {command} oci start busybox
 
 ..
-   ~$ sudo singularity oci state busybox
+   ~$ sudo {command} oci state busybox
 
 ..
    TODO Review CC's responses again ... see GDocs note on March 20, 2019
@@ -893,7 +893,7 @@ be issued:
 
 .. code::
 
-   $ sudo singularity oci umount /var/tmp/busybox
+   $ sudo {command} oci umount /var/tmp/busybox
 
 .. note::
 
@@ -926,25 +926,25 @@ be issued:
    CC's suggested workflow:
 
 ..
-   singularity build /tmp/test.sif docker://busybox
+   {command} build /tmp/test.sif docker://busybox
 
 ..
-   sudo singularity oci mount /tmp/test.sif /var/tmp/busy
+   sudo {command} oci mount /tmp/test.sif /var/tmp/busy
 
 ..
-   sudo singularity oci create -b /var/tmp/busy testing > /dev/null 2>&1
+   sudo {command} oci create -b /var/tmp/busy testing > /dev/null 2>&1
 
 ..
-   sudo singularity oci start testing
+   sudo {command} oci start testing
 
 ..
-   sudo singularity oci exec testing /bin/sh
+   sudo {command} oci exec testing /bin/sh
 
 ..
-   sudo singularity oci kill testing
+   sudo {command} oci kill testing
 
 ..
-   sudo singularity oci delete testing
+   sudo {command} oci delete testing
 
 ..
-   sudo singularity oci umount /var/tmp/busy
+   sudo {command} oci umount /var/tmp/busy

--- a/oci_runtime.rst
+++ b/oci_runtime.rst
@@ -69,7 +69,7 @@ This is one way to bootstrap creation of this image in SIF that
 *retains* a local copy - i.e., a local copy of the SIF file *and* a
 cached copy of the OCI blobs. Additional approaches and details can be
 found in the section :ref:`Support for Docker and OCI
-<singularity-and-docker>`).
+<docker-and-oci>`).
 
 For the purpose of bootstrapping the creation of an OCI compliant
 container, this SIF file can be mounted as follows:
@@ -773,7 +773,7 @@ additional properties - for example:
    will make use of ``ENTRYPOINT`` or ``CMD`` (from the OCI image) to
    populate ``args``; for additional discussion, please refer to
    :ref:`Directing Execution <sec:def_files_execution>` in the section
-   :ref:`Support for Docker and OCI <singularity-and-docker>`.
+   :ref:`Support for Docker and OCI <docker-and-oci>`.
 
 For a comprehensive discussion of all the ``config.json`` file
 properties, refer to the `implementation guide

--- a/persistent_overlays.rst
+++ b/persistent_overlays.rst
@@ -42,12 +42,12 @@ To use a persistent overlay, you must first have a container.
 
 .. code::
 
-   $ sudo singularity build ubuntu.sif library://ubuntu
+   $ sudo {command} build ubuntu.sif library://ubuntu
 
 File system image overlay
 =========================
 
-{Project} provides a command ``singularity overlay
+{Project} provides a command ``{command} overlay
 create`` to create persistent overlay images. You can create a single
 EXT3 overlay image or adding a EXT3 writable overlay partition to an
 existing SIF image.
@@ -62,13 +62,13 @@ For example, to create a 1 GiB overlay image:
 
 .. code::
 
-   $ singularity overlay create --size 1024 /tmp/ext3_overlay.img
+   $ {command} overlay create --size 1024 /tmp/ext3_overlay.img
 
 To add a 1 GiB writable overlay partition to an existing SIF image:
 
 .. code::
 
-   $ singularity overlay create --size 1024 ubuntu.sif
+   $ {command} overlay create --size 1024 ubuntu.sif
 
 .. warning::
 
@@ -76,7 +76,7 @@ To add a 1 GiB writable overlay partition to an existing SIF image:
    **signed**, **encrypted** SIF image or if the SIF image already
    contain a writable overlay partition.
 
-``singularity overlay create`` also provides an option ``--create-dir``
+``{command} overlay create`` also provides an option ``--create-dir``
 to create additional directories owned by the calling user, it can be
 specified multiple times to create many directories. This is
 particularly useful when you need to make a directory writable by your
@@ -86,9 +86,9 @@ So for example:
 
 .. code::
 
-   $ singularity build /tmp/nginx.sif docker://nginx
-   $ singularity overlay create --size 1024 --create-dir /var/cache/nginx /tmp/nginx.sif
-   $ echo "test" | singularity exec /tmp/nginx.sif sh -c "cat > /var/cache/nginx/test"
+   $ {command} build /tmp/nginx.sif docker://nginx
+   $ {command} overlay create --size 1024 --create-dir /var/cache/nginx /tmp/nginx.sif
+   $ echo "test" | {command} exec /tmp/nginx.sif sh -c "cat > /var/cache/nginx/test"
 
 Directory overlay
 =================
@@ -113,7 +113,7 @@ The example below shows the directory overlay in action.
 
 .. code::
 
-   $ sudo singularity shell --overlay my_overlay/ ubuntu.sif
+   $ sudo {command} shell --overlay my_overlay/ ubuntu.sif
 
    {Project} ubuntu.sif:~> mkdir /data
 
@@ -146,7 +146,7 @@ functionality of {Project}.
 
 .. code::
 
-   $ singularity sif add --datatype 4 --partfs 2 --parttype 4 --partarch 2 --groupid 1 ubuntu_latest.sif overlay.img
+   $ {command} sif add --datatype 4 --partfs 2 --parttype 4 --partarch 2 --groupid 1 ubuntu_latest.sif overlay.img
 
 Below is the explanation what each parameter means, and how it can
 possibly affect the operation:
@@ -163,14 +163,14 @@ possibly affect the operation:
    there's no more than one group, therefore we can assume it is 1.
 
 All of these options are documented within the CLI help. Access it by
-running ``singularity sif add --help``.
+running ``{command} sif add --help``.
 
 After you've completed the steps above, you can shell into your
 container with the ``--writable`` option.
 
 .. code::
 
-   $ sudo singularity shell --writable ubuntu_latest.sif
+   $ sudo {command} shell --writable ubuntu_latest.sif
 
 Final note
 ==========
@@ -180,7 +180,7 @@ were using a writable container.
 
 .. code::
 
-   $ singularity shell --overlay my_overlay/ ubuntu.sif
+   $ {command} shell --overlay my_overlay/ ubuntu.sif
 
    {Project} ubuntu.sif:~> ls -lasd /data
    4 drwxr-xr-x 2 user root 4096 Apr  9 10:21 /data
@@ -195,7 +195,7 @@ changes will be gone.
 
 .. code::
 
-   $ singularity shell ubuntu.sif
+   $ {command} shell ubuntu.sif
 
    {Project} ubuntu.sif:~> ls /data
    ls: cannot access 'data': No such file or directory

--- a/plugins.rst
+++ b/plugins.rst
@@ -23,7 +23,7 @@ The ``list`` command prints the currently installed plugins.
 
 .. code::
 
-   $ singularity plugin list
+   $ {command} plugin list
    There are no plugins installed.
 
 Plugins are packaged and distributed as binaries encoded with the
@@ -34,7 +34,7 @@ plugin ``test-plugin`` is included with the {Project} source code.
 
 .. code::
 
-   $ singularity plugin compile examples/plugins/test-plugin/
+   $ {command} plugin compile examples/plugins/test-plugin/
 
 Upon successful compilation, a SIF file will appear in the directory of
 the plugin's source code.
@@ -53,7 +53,7 @@ the plugin's source code.
    written in is quite restrictive - it requires extremely close version
    matching of packages used in a plugin to the ones used in the program
    the plugin is built for. Additionally {Project} is using build
-   time config to get the source tree location for ``singularity plugin
+   time config to get the source tree location for ``{command} plugin
    compile`` so that you don't need to export environment variables etc,
    and there isn't mismatch between package path information that Go
    uses. This means that at present you must:
@@ -71,7 +71,7 @@ plugin, use the ``inspect`` command.
 
 .. code::
 
-   $ singularity plugin inspect examples/plugins/test-plugin/test-plugin.sif
+   $ {command} plugin inspect examples/plugins/test-plugin/test-plugin.sif
    Name: sylabs.io/test-plugin
    Description: This is a short test plugin for {Project}
    Author: Michael Bauer
@@ -82,8 +82,8 @@ requires root privilege.
 
 .. code::
 
-   $ sudo singularity plugin install examples/plugins/test-plugin/test-plugin.sif
-   $ singularity plugin list
+   $ sudo {command} plugin install examples/plugins/test-plugin/test-plugin.sif
+   $ {command} plugin list
    ENABLED  NAME
        yes  sylabs.io/test-plugin
 
@@ -94,12 +94,12 @@ privilege.
 
 .. code::
 
-   $ sudo singularity plugin disable sylabs.io/test-plugin
-   $ singularity plugin list
+   $ sudo {command} plugin disable sylabs.io/test-plugin
+   $ {command} plugin list
    ENABLED  NAME
         no  sylabs.io/test-plugin
-   $ sudo singularity plugin enable sylabs.io/test-plugin
-   $ singularity plugin list
+   $ sudo {command} plugin enable sylabs.io/test-plugin
+   $ {command} plugin list
    ENABLED  NAME
        yes  sylabs.io/test-plugin
 
@@ -108,9 +108,9 @@ operation requires root privilege.
 
 .. code::
 
-   $ sudo singularity plugin uninstall sylabs.io/test-plugin
+   $ sudo {command} plugin uninstall sylabs.io/test-plugin
    Uninstalled plugin "sylabs.io/test-plugin".
-   $ singularity plugin list
+   $ {command} plugin list
    There are no plugins installed.
 
 ******************

--- a/pygments_apptainer.py
+++ b/pygments_apptainer.py
@@ -3,15 +3,15 @@ from pygments.token import *
 from pygments.lexers.shell import BashLexer
 import re
 
-class SingularityLexer(RegexLexer):
+class ApptainerLexer(RegexLexer):
     """
-    Lexer for `Singularity definition files
+    Lexer for `Apptainer definition files
     <https://www.sylabs.io/guides/3.0/user-guide/definition_files.html>`_.
     """
 
-    name = 'Singularity'
-    aliases = ['singularity']
-    filenames = ['*.def', 'Singularity']
+    name = 'Apptainer'
+    aliases = ['apptainer']
+    filenames = ['*.def', 'Apptainer']
     flags = re.IGNORECASE | re.MULTILINE | re.DOTALL
 
     _headers = r'^(\s)*(bootstrap|from|osversion|mirrorurl|include|registry|namespace|includecmd|fingerprints)(:)'

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -140,9 +140,9 @@ the installation.
 .. code::
 
    $ export VERSION={InstallationVersion} && # adjust this as necessary \
-       wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
-       tar -xzf singularity-${VERSION}.tar.gz && \
-       cd singularity-${VERSION}
+       wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/{command}-${VERSION}.tar.gz && \
+       tar -xzf {command}-${VERSION}.tar.gz && \
+       cd {command}-${VERSION}
 
 .. _compile:
 
@@ -176,13 +176,13 @@ subcommands as follows:
 
 .. code::
 
-   $ singularity help
+   $ {command} help
 
    Linux container platform optimized for High Performance Computing (HPC) and
    Enterprise Performance Computing (EPC)
 
    Usage:
-     singularity [global options...]
+     {command} [global options...]
 
    Description:
      {Project} containers provide an application virtualization layer enabling
@@ -192,7 +192,7 @@ subcommands as follows:
 
    Options:
      -d, --debug     print debugging information (highest verbosity)
-     -h, --help      help for singularity
+     -h, --help      help for {command}
          --nocolor   print without color output (default False)
      -q, --quiet     suppress normal output
      -s, --silent    only print errors
@@ -208,10 +208,10 @@ subcommands as follows:
      instance    Manage containers running as services
      key         Manage OpenPGP keys
      oci         Manage OCI containers
-     plugin      Manage singularity plugins
+     plugin      Manage {command} plugins
      pull        Pull an image from a URI
      push        Upload image to the provided library (default is "cloud.sylabs.io")
-     remote      Manage singularity remote endpoints
+     remote      Manage {command} remote endpoints
      run         Run the user-defined default command within a container
      run-help    Show the user-defined help for an image
      search      Search a Container Library for images
@@ -223,9 +223,9 @@ subcommands as follows:
      version     Show the version for {Project}
 
    Examples:
-     $ singularity help <command> [<subcommand>]
-     $ singularity help build
-     $ singularity help instance start
+     $ {command} help <command> [<subcommand>]
+     $ {command} help build
+     $ {command} help instance start
 
 
    For additional help or support, please visit https://www.sylabs.io/docs/
@@ -235,11 +235,11 @@ command.
 
 .. code::
 
-   $ singularity help verify
+   $ {command} help verify
    Verify cryptographic signatures attached to an image
 
    Usage:
-     singularity verify [verify options...] <image path>
+     {command} verify [verify options...] <image path>
 
    Description:
      The verify command allows a user to verify cryptographic signatures on SIF
@@ -261,29 +261,29 @@ command.
 
 
    Examples:
-     $ singularity verify container.sif
+     $ {command} verify container.sif
 
 
    For additional help or support, please visit https://www.sylabs.io/docs/
 
 {Project} uses positional syntax (i.e. the order of commands and
 options matters). Global options affecting the behavior of all commands
-follow the main ``singularity`` command. Then sub commands are followed
+follow the main ``{command}`` command. Then sub commands are followed
 by their options and arguments.
 
-For example, to pass the ``--debug`` option to the main ``singularity``
+For example, to pass the ``--debug`` option to the main ``{command}``
 command and run {Project} with debugging messages on:
 
 .. code::
 
-   $ singularity --debug run library://lolcow
+   $ {command} --debug run library://lolcow
 
 To pass the ``--containall`` option to the ``run`` command and run a
 {Project} image in an isolated manner:
 
 .. code::
 
-   $ singularity run --containall library://lolcow
+   $ {command} run --containall library://lolcow
 
 {Project} has the concept of command groups. For
 instance, to list Linux capabilities for a particular user, you would
@@ -291,7 +291,7 @@ use the ``list`` command in the ``capability`` command group like so:
 
 .. code::
 
-   $ singularity capability list dave
+   $ {command} capability list dave
 
 Container authors might also write help docs specific to a container or
 for an internal module called an ``app``. If those help docs exist for a
@@ -299,9 +299,9 @@ particular container, you can view them like so.
 
 .. code::
 
-   $ singularity inspect --helpfile container.sif  # See the container's help, if provided
+   $ {command} inspect --helpfile container.sif  # See the container's help, if provided
 
-   $ singularity inspect --helpfile --app=foo foo.sif  # See the help for foo, if provided
+   $ {command} inspect --helpfile --app=foo foo.sif  # See the help for foo, if provided
 
 ***************************
  Download pre-built images
@@ -313,7 +313,7 @@ containers of interest on the `Container Library
 
 .. code::
 
-   singularity search tensorflow
+   {command} search tensorflow
    Found 22 container images for amd64 matching "tensorflow":
 
        library://ajgreen/default/tensorflow2-gpu-py3-r-jupyter:latest
@@ -340,9 +340,9 @@ containers of interest on the `Container Library
        ...
 
 You can use the `pull
-<cli/singularity_pull.html>`_
+<cli/{command}_pull.html>`_
 and `build
-<cli/singularity_build.html>`_
+<cli/{command}_build.html>`_
 commands to download pre-built images from an external resource like the
 `Container Library <https://cloud.sylabs.io/library>`_ or `Docker Hub
 <https://hub.docker.com/>`_.
@@ -353,7 +353,7 @@ system.
 
 .. code::
 
-   $ singularity pull library://lolcow
+   $ {command} pull library://lolcow
 
 You can also use ``pull`` with the ``docker://`` uri to reference Docker
 images served from a registry. In this case ``pull`` does not just
@@ -362,7 +362,7 @@ must also combine those layers into a usable {Project} file.
 
 .. code::
 
-   $ singularity pull docker://sylabsio/lolcow
+   $ {command} pull docker://sylabsio/lolcow
 
 Pulling Docker images reduces reproducibility. If you were to pull a
 Docker image today and then wait six months and pull again, you are not
@@ -376,9 +376,9 @@ your container like so:
 
 .. code::
 
-   $ singularity build ubuntu.sif library://ubuntu
+   $ {command} build ubuntu.sif library://ubuntu
 
-   $ singularity build lolcow.sif docker://sylabsio/lolcow
+   $ {command} build lolcow.sif docker://sylabsio/lolcow
 
 Unlike ``pull``, ``build`` will convert your image to the latest
 {Project} image format after downloading it. ``build`` is like a
@@ -404,19 +404,19 @@ pulled from the Container Library:
 
 .. code::
 
-   $ singularity pull library://lolcow
+   $ {command} pull library://lolcow
 
 Shell
 =====
 
 The `shell
-<cli/singularity_shell.html>`_
+<cli/{command}_shell.html>`_
 command allows you to spawn a new shell within your container and
 interact with it as though it were a small virtual machine.
 
 .. code::
 
-   $ singularity shell lolcow_latest.sif
+   $ {command} shell lolcow_latest.sif
 
    {Project} lolcow_latest.sif:~>
 
@@ -441,20 +441,20 @@ when the shell is exited.
 
 .. code::
 
-   $ singularity shell library://lolcow
+   $ {command} shell library://lolcow
 
 Executing Commands
 ==================
 
 The `exec
-<cli/singularity_exec.html>`_
+<cli/{command}_exec.html>`_
 command allows you to execute a custom command within a container by
 specifying the image file. For instance, to execute the ``cowsay``
 program within the ``lolcow_latest.sif`` container:
 
 .. code::
 
-   $ singularity exec lolcow_latest.sif cowsay moo
+   $ {command} exec lolcow_latest.sif cowsay moo
     _____
    < moo >
     -----
@@ -470,7 +470,7 @@ command and disappears.
 
 .. code::
 
-   $ singularity exec library://lolcow cowsay "Fresh from the library!"
+   $ {command} exec library://lolcow cowsay "Fresh from the library!"
     _________________________
    < Fresh from the library! >
     -------------------------
@@ -489,13 +489,13 @@ Running a container
 are user defined scripts that define the actions a container should
 perform when someone runs it. The runscript can be triggered with the
 `run
-<cli/singularity_run.html>`_
+<cli/{command}_run.html>`_
 command, or simply by calling the container as though it were an
 executable.
 
 .. code::
 
-   $ singularity run lolcow_latest.sif
+   $ {command} run lolcow_latest.sif
    ______________________________
    < Mon Aug 16 13:01:55 CDT 2021 >
     ------------------------------
@@ -521,7 +521,7 @@ disappears.
 
 .. code::
 
-   $ singularity run library://lolcow
+   $ {command} run library://lolcow
    ______________________________
    < Mon Aug 16 13:12:33 CDT 2021 >
     ------------------------------
@@ -542,7 +542,7 @@ to run ``echo`` command in this shell:
 
 .. code::
 
-   $ singularity run library://alpine echo "hello"
+   $ {command} run library://alpine echo "hello"
 
    hello
 
@@ -557,10 +557,10 @@ quoting of arguments.
    $ docker run -it --rm alpine echo "\$HOSTNAME"
    $HOSTNAME
 
-   $ singularity run docker://alpine echo "\$HOSTNAME"
+   $ {command} run docker://alpine echo "\$HOSTNAME"
    p700
 
-   $ singularity run docker://alpine echo "\\\$HOSTNAME"
+   $ {command} run docker://alpine echo "\\\$HOSTNAME"
    $HOSTNAME
 
 The ``exec`` command replicates the Docker/OCI behavior as it calls
@@ -576,7 +576,7 @@ Files on the host are reachable from within the container.
 
    $ echo "Hello from inside the container" > $HOME/hostfile.txt
 
-   $ singularity exec lolcow_latest.sif cat $HOME/hostfile.txt
+   $ {command} exec lolcow_latest.sif cat $HOME/hostfile.txt
 
    Hello from inside the container
 
@@ -593,7 +593,7 @@ container.
 
    $ echo "Drink milk (and never eat hamburgers)." > /data/cow_advice.txt
 
-   $ singularity exec --bind /data:/mnt lolcow_latest.sif cat /mnt/cow_advice.txt
+   $ {command} exec --bind /data:/mnt lolcow_latest.sif cat /mnt/cow_advice.txt
    Drink milk (and never eat hamburgers).
 
 Pipes and redirects also work with {Project} commands just like they
@@ -601,7 +601,7 @@ do with normal Linux commands.
 
 .. code::
 
-   $ cat /data/cow_advice.txt | singularity exec lolcow_latest.sif cowsay
+   $ cat /data/cow_advice.txt | {command} exec lolcow_latest.sif cowsay
     ________________________________________
    < Drink milk (and never eat hamburgers). >
     ----------------------------------------
@@ -638,7 +638,7 @@ To build into a ``sandbox`` (container in a directory) use the ``build
 
 .. code::
 
-   $ sudo singularity build --sandbox ubuntu/ library://ubuntu
+   $ sudo {command} build --sandbox ubuntu/ library://ubuntu
 
 This command creates a directory called ``ubuntu/`` with an entire
 Ubuntu Operating System and some {Project} metadata in your current
@@ -652,9 +652,9 @@ do so).
 
 .. code::
 
-   $ sudo singularity exec --writable ubuntu touch /foo
+   $ sudo {command} exec --writable ubuntu touch /foo
 
-   $ singularity exec ubuntu/ ls /foo
+   $ {command} exec ubuntu/ ls /foo
    /foo
 
 Converting images from one format to another
@@ -668,7 +668,7 @@ image format (squashfs) you can do so:
 
 .. code::
 
-   $ singularity build new-sif sandbox
+   $ {command} build new-sif sandbox
 
 Doing so may break reproducibility if you have altered your sandbox
 outside of the context of a definition file, so you are advised to
@@ -690,7 +690,7 @@ setup, and copying files into the container from host system, etc.
 
 Here is an example of a definition file:
 
-.. code:: singularity
+.. code:: {command}
 
    BootStrap: library
    From: ubuntu:16.04
@@ -714,7 +714,7 @@ named lolcow.def), you would call build like so:
 
 .. code::
 
-   $ sudo singularity build lolcow.sif lolcow.def
+   $ sudo {command} build lolcow.sif lolcow.def
 
 In this example, the header tells {Project} to use a base Ubuntu
 16.04 image from the Container Library.
@@ -796,7 +796,7 @@ similar to this:
        {admindocs}/installation.html
 
    If you have questions about any of the above, you can contact one of the
-   sources listed at https://apptainer.org/help. I can do my best
+   sources listed at https://{command}.org/help. I can do my best
    to facilitate this interaction if help is needed.
 
    Thank you kindly for considering this request!

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -796,7 +796,7 @@ similar to this:
        {admindocs}/installation.html
 
    If you have questions about any of the above, you can contact one of the
-   sources listed at https://{command}.org/help. I can do my best
+   sources listed at https://apptainer.org/help. I can do my best
    to facilitate this interaction if help is needed.
 
    Thank you kindly for considering this request!

--- a/replacements.py
+++ b/replacements.py
@@ -17,6 +17,7 @@ variable_replacements = {
     "{version}": "main",
     "{adminversion}": "main",
     "{Project}": "Apptainer",
+    "{command}": "apptainer",
     "{ENVPREFIX}": "APPTAINER",
 }
 

--- a/running_services.rst
+++ b/running_services.rst
@@ -57,7 +57,7 @@ image from the `container library <https://cloud.sylabs.io/library/>`_:
 
 .. code::
 
-   $ singularity pull library://alpine
+   $ {command} pull library://alpine
 
 The above command will save the alpine image from the Container Library
 as ``alpine_latest.sif``.
@@ -68,7 +68,7 @@ To start an instance, you should follow this procedure :
 
    [command]                      [image]              [name of instance]
 
-   $ singularity instance start   alpine_latest.sif     instance1
+   $ {command} instance start   alpine_latest.sif     instance1
 
 This command causes {Project} to create an isolated environment for
 the container services to live inside. One can confirm that an instance
@@ -76,7 +76,7 @@ is running by using the ``instance list`` command like so:
 
 .. code::
 
-   $ singularity instance list
+   $ {command} instance list
 
    INSTANCE NAME    PID      IP              IMAGE
    instance1        22084                    /home/dave/instances/alpine_latest.sif
@@ -96,15 +96,15 @@ repeated.
 
 .. code::
 
-   $ singularity instance start alpine_latest.sif instance2
+   $ {command} instance start alpine_latest.sif instance2
 
-   $ singularity instance start alpine_latest.sif instance3
+   $ {command} instance start alpine_latest.sif instance3
 
 And again to confirm that the instances are running as we expected:
 
 .. code::
 
-   $ singularity instance list
+   $ {command} instance list
 
    INSTANCE NAME    PID      IP              IMAGE
    instance1        22084                    /home/dave/instances/alpine_latest.sif
@@ -115,29 +115,29 @@ You can also filter the instance list by supplying a pattern:
 
 .. code::
 
-   $ singularity instance list '*2'
+   $ {command} instance list '*2'
 
    INSTANCE NAME    PID      IP              IMAGE
    instance2        22443                    /home/dave/instances/alpine_latest.s
 
-You can use the ``singularity run/exec`` commands on instances:
+You can use the ``{command} run/exec`` commands on instances:
 
 .. code::
 
-   $ singularity run instance://instance1
+   $ {command} run instance://instance1
 
-   $ singularity exec instance://instance2 cat /etc/os-release
+   $ {command} exec instance://instance2 cat /etc/os-release
 
 When using ``run`` with an instance URI, the ``runscript`` will be
 executed inside of the instance. Similarly with ``exec``, it will
 execute the given command in the instance.
 
 If you want to poke around inside of your instance, you can do a normal
-``singularity shell`` command, but give it the instance URI:
+``{command} shell`` command, but give it the instance URI:
 
 .. code::
 
-   $ singularity shell instance://instance3
+   $ {command} shell instance://instance3
 
    {Project}>
 
@@ -146,7 +146,7 @@ When you are finished with your instance you can clean it up with the
 
 .. code::
 
-   $ singularity instance stop instance1
+   $ {command} instance stop instance1
 
 If you have multiple instances running and you want to stop all of them,
 you can do so with a wildcard or the --all flag. The following three
@@ -154,11 +154,11 @@ commands are all identical.
 
 .. code::
 
-   $ singularity instance stop \*
+   $ {command} instance stop \*
 
-   $ singularity instance stop --all
+   $ {command} instance stop --all
 
-   $ singularity instance stop -a
+   $ {command} instance stop -a
 
 .. note::
 
@@ -176,7 +176,7 @@ example of setting up a sample NGINX web server using instances. First
 we will create a basic :ref:`definition file <definition-files>` (let's
 call it nginx.def):
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: nginx
@@ -192,9 +192,9 @@ following commands as root.
 
 .. code::
 
-   $ sudo singularity build nginx.sif nginx.def
+   $ sudo {command} build nginx.sif nginx.def
 
-   $ sudo singularity instance start --writable-tmpfs nginx.sif web
+   $ sudo {command} instance start --writable-tmpfs nginx.sif web
 
 .. note::
 
@@ -251,7 +251,7 @@ the final image directly from Container Library, simply run:
 
 .. code::
 
-   $ singularity pull url-to-pdf.sif library://sylabs/doc-examples/url-to-pdf:latest
+   $ {command} pull url-to-pdf.sif library://sylabs/doc-examples/url-to-pdf:latest
 
 Building the image
 ==================
@@ -264,7 +264,7 @@ version of Chromium called `Puppeteer
 from which to build our container, in this case the docker image
 ``node:8`` which comes pre-installed with Node 8 has been used:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: node:8
@@ -274,7 +274,7 @@ Puppeteer also requires a slew of dependencies to be manually installed
 in addition to Node 8, so we can add those into the ``post`` section as
 well as the installation script for the ``url-to-pdf``:
 
-.. code:: singularity
+.. code:: {command}
 
    %post
 
@@ -296,7 +296,7 @@ And now we need to define what happens when we start an instance of the
 container. In this situation, we want to run the commands that starts up
 the url-to-pdf service:
 
-.. code:: singularity
+.. code:: {command}
 
    %startscript
        cd /pdf_server
@@ -306,7 +306,7 @@ the url-to-pdf service:
 Also, the ``url-to-pdf`` service requires some environment variables to
 be set, which we can do in the environment section:
 
-.. code:: singularity
+.. code:: {command}
 
    %environment
        NODE_ENV=development
@@ -317,7 +317,7 @@ be set, which we can do in the environment section:
 
 The complete definition file will look like this:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: node:8
@@ -355,7 +355,7 @@ The container can be built like so:
 
 .. code::
 
-   $ sudo singularity build url-to-pdf.sif url-to-pdf.def
+   $ sudo {command} build url-to-pdf.sif url-to-pdf.def
 
 Running the Service
 ===================
@@ -364,7 +364,7 @@ We can now start an instance and run the service:
 
 .. code::
 
-   $ sudo singularity instance start url-to-pdf.sif pdf
+   $ sudo {command} instance start url-to-pdf.sif pdf
 
 .. note::
 
@@ -394,7 +394,7 @@ If you shell into the instance, you can see the running processes:
 
 .. code::
 
-   $ sudo singularity shell instance://pdf
+   $ sudo {command} shell instance://pdf
    {Project}: Invoking an interactive shell within container...
 
    {Project} final.sif:/home/ysub> ps auxf
@@ -439,7 +439,7 @@ an app, so that there is a designated spot to place output files. To do
 that, we want to add a section to our definition file to build the
 server:
 
-.. code:: singularity
+.. code:: {command}
 
    %appinstall pdf_server
        git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
@@ -449,7 +449,7 @@ server:
 
 And update our ``startscript`` to point to the app location:
 
-.. code:: singularity
+.. code:: {command}
 
    %startscript
        cd /scif/apps/pdf_server/scif/pdf_server
@@ -459,11 +459,11 @@ And update our ``startscript`` to point to the app location:
 Now we want to define the pdf_client app, which we will run to send the
 requests to the server:
 
-.. code:: singularity
+.. code:: {command}
 
    %apprun pdf_client
        if [ -z "${1:-}" ]; then
-           echo "Usage: singularity run --app pdf <instance://name> <URL> [output file]"
+           echo "Usage: {command} run --app pdf <instance://name> <URL> [output file]"
            exit 1
        fi
        curl -o "${APPTAINER_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
@@ -473,7 +473,7 @@ provides at least one argument.
 
 The full def file will look like this:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: node:8
@@ -511,7 +511,7 @@ The full def file will look like this:
 
    %apprun pdf_client
        if [ -z "${1:-}" ]; then
-           echo "Usage: singularity run --app pdf <instance://name> <URL> [output file]"
+           echo "Usage: {command} run --app pdf <instance://name> <URL> [output file]"
            exit 1
        fi
        curl -o "${APPTAINER_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
@@ -521,7 +521,7 @@ the old container:
 
 .. code::
 
-   $ sudo singularity build --force url-to-pdf.sif url-to-pdf.def
+   $ sudo {command} build --force url-to-pdf.sif url-to-pdf.def
 
 Now that we have an output directory in the container, we need to expose
 it to the host using a bind mount. Once we’ve rebuilt the container,
@@ -536,13 +536,13 @@ the instance:
 
 .. code::
 
-   $ singularity instance start --bind /tmp/out/:/output url-to-pdf.sif pdf
+   $ {command} instance start --bind /tmp/out/:/output url-to-pdf.sif pdf
 
 To request a pdf simply do:
 
 .. code::
 
-   $ singularity run --app pdf_client instance://pdf http://sylabs.io/docs sylabs.pdf
+   $ {command} run --app pdf_client instance://pdf http://sylabs.io/docs sylabs.pdf
 
 To confirm that it worked:
 
@@ -556,7 +556,7 @@ running instances.
 
 .. code::
 
-   $ singularity instance stop --all
+   $ {command} instance stop --all
 
 .. note::
 
@@ -568,7 +568,7 @@ running instances.
 
    .. code::
 
-      $ singularity instance start --bind output/dir/outside/:/output/ nginx.sif  web
+      $ {command} instance start --bind output/dir/outside/:/output/ nginx.sif  web
 
 ********************************
  System integration / PID files
@@ -580,12 +580,12 @@ performed by an init process, or another supervisor daemon installed on
 your host. Many init and supervisor daemons support managing processes
 via pid files.
 
-You can specify a `--pid-file` option to `singularity instance start` to
+You can specify a `--pid-file` option to `{command} instance start` to
 write the PID for an instance to the specified file, e.g.
 
 .. code::
 
-   $ singularity instance start --pid-file /home/dave/alpine.pid alpine_latest.sif instanceA
+   $ {command} instance start --pid-file /home/dave/alpine.pid alpine_latest.sif instanceA
 
    $ cat /home/dave/alpine.pid
    23727
@@ -606,8 +606,8 @@ systemd.
    User=www-data
    Group=www-data
    PIDFile=/run/web-instance.pid
-   ExecStart=/usr/local/bin/singularity instance start --pid-file /run/web-instance.pid /data/containers/web.sif web-instance
-   ExecStop=/usr/local/bin/singularity instance stop web-instance
+   ExecStart=/usr/local/bin/{command} instance start --pid-file /run/web-instance.pid /data/containers/web.sif web-instance
+   ExecStop=/usr/local/bin/{command} instance stop web-instance
 
    [Install]
    WantedBy=multi-user.target

--- a/security.rst
+++ b/security.rst
@@ -11,8 +11,8 @@
 If you suspect you have found a vulnerability in {Project} we want
 to work with you so that it can be investigated, fixed, and disclosed in
 a responsible manner. Please follow the steps in our published `Security
-Policy <https://apptainer.org/security-policy/>`__, which begins with
-contacting us privately via security@apptainer.org
+Policy <https://{command}.org/security-policy/>`__, which begins with
+contacting us privately via security@{command}.org
 
 We disclose vulnerabilities found in {Project} through public
 CVE reports, and notifications on our community channels. We encourage
@@ -61,9 +61,9 @@ to run a container can be run, unprivileged.
 
 {Project} supports running containers without setuid, using user
 namespaces. It can be compiled with the ``--without-suid`` option, or
-``allow setuid = no`` can be set in ``singularity.conf`` to enable this.
+``allow setuid = no`` can be set in ``{command}.conf`` to enable this.
 In this mode *all* operations run as the user who starts the
-``singularity`` program. However, there are some disadvantages:
+``{command}`` program. However, there are some disadvantages:
 
 -  SIF and other single file container images cannot be mounted
    directly. The container image must be extracted to a directory on
@@ -145,7 +145,7 @@ to verify that the image has not been tampered with or corrupted.
 
 We use private PGP keys to create a container signature, and the public
 key in order to verify the container. Verification of signed containers
-happens automatically in ``singularity pull`` commands against the
+happens automatically in ``{command} pull`` commands against the
 Sylabs Cloud Container Library. A Keystore in the Sylabs Cloud makes it
 easier to share and obtain public keys for container verification.
 

--- a/security.rst
+++ b/security.rst
@@ -11,8 +11,8 @@
 If you suspect you have found a vulnerability in {Project} we want
 to work with you so that it can be investigated, fixed, and disclosed in
 a responsible manner. Please follow the steps in our published `Security
-Policy <https://{command}.org/security-policy/>`__, which begins with
-contacting us privately via security@{command}.org
+Policy <https://apptainer.org/security-policy/>`__, which begins with
+contacting us privately via security@apptainer.org
 
 We disclose vulnerabilities found in {Project} through public
 CVE reports, and notifications on our community channels. We encourage

--- a/security_options.rst
+++ b/security_options.rst
@@ -212,7 +212,7 @@ on Ubuntu and that {Project} was installed with the
 
 First write a configuration file. An example configuration file is
 installed with {Project}, normally at
-``/usr/local/etc/singularity/seccomp-profiles/default.json``. For this
+``/usr/local/etc/{command}/seccomp-profiles/default.json``. For this
 example, we will use a much simpler configuration file to blacklist the
 ``mkdir`` command.
 

--- a/security_options.rst
+++ b/security_options.rst
@@ -44,7 +44,7 @@ also request the capability when executing a container with the
 
 .. code::
 
-   $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   $ {command} exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
    64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=73.1 ms
 
@@ -59,7 +59,7 @@ to add that capability to their containers anymore:
 
 .. code::
 
-   $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   $ {command} exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
    WARNING: not authorized to add capability: CAP_NET_RAW
    ping: socket: Operation not permitted
 
@@ -80,7 +80,7 @@ above works without the need to grant capabilities:
 
 .. code::
 
-   # singularity exec library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   # {command} exec library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
    64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=59.6 ms
 
@@ -92,7 +92,7 @@ Now we can manually drop the ``CAP_NET_RAW`` capability like so:
 
 .. code::
 
-   # singularity exec --drop-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   # {command} exec --drop-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
    ping: socket: Operation not permitted
 
 And now the container will not have the ability to create new sockets,
@@ -144,7 +144,7 @@ container with the ``--allow-setuid`` option like so:
 
 .. code::
 
-   $ sudo singularity shell --allow-setuid some_container.sif
+   $ sudo {command} shell --allow-setuid some_container.sif
 
 ``--keep-privs``
 ================
@@ -152,14 +152,14 @@ container with the ``--allow-setuid`` option like so:
 It is possible for an admin to set a different set of default
 capabilities or to reduce the default capabilities to zero for the root
 user by setting the ``root default capabilities`` parameter in the
-``singularity.conf`` file to ``file`` or ``no`` respectively. If this
-change is in effect, the root user can override the ``singularity.conf``
+``{command}.conf`` file to ``file`` or ``no`` respectively. If this
+change is in effect, the root user can override the ``{command}.conf``
 file and enter the container with full capabilities using the
 ``--keep-privs`` option.
 
 .. code::
 
-   $ sudo singularity exec --keep-privs library://centos ping -c 1 8.8.8.8
+   $ sudo {command} exec --keep-privs library://centos ping -c 1 8.8.8.8
    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
    64 bytes from 8.8.8.8: icmp_seq=1 ttl=128 time=18.8 ms
 
@@ -179,7 +179,7 @@ inside the container:
 
 .. code::
 
-   $ sudo singularity exec --drop-caps CAP_NET_RAW library://centos ping -c 1 8.8.8.8
+   $ sudo {command} exec --drop-caps CAP_NET_RAW library://centos ping -c 1 8.8.8.8
    ping: socket: Operation not permitted
 
 The ``drop-caps`` option will also accept the case insensitive keyword
@@ -201,7 +201,7 @@ For instance:
    $ sudo whoami
    root
 
-   $ sudo singularity exec --security uid:1000 my_container.sif whoami
+   $ sudo {command} exec --security uid:1000 my_container.sif whoami
    david
 
 To use seccomp to blacklist a command follow this procedure. (It is
@@ -248,7 +248,7 @@ the container like so:
 
 .. code::
 
-   $ sudo singularity shell --security seccomp:/home/david/no_mkdir.json my_container.sif
+   $ sudo {command} shell --security seccomp:/home/david/no_mkdir.json my_container.sif
 
    {Project}> mkdir /tmp/foo
    Bad system call (core dumped)
@@ -261,7 +261,7 @@ follows:
 
 .. code::
 
-   --security="seccomp:/usr/local/etc/singularity/seccomp-profiles/default.json"
+   --security="seccomp:/usr/local/etc/{command}/seccomp-profiles/default.json"
    --security="apparmor:/usr/bin/man"
    --security="selinux:context"
    --security="uid:1000"

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -102,7 +102,7 @@ or saved locally.`
 
    $ {command} key list
 
-   Public key listing (/home/dave/.singularity/sypgp/pgp-public):
+   Public key listing (/home/dave/.{command}/sypgp/pgp-public):
 
    0) U: David Trudgian (demo) <david.trudgian@sylabs.io>
       C: 2019-11-15 09:54:54 -0600 CST
@@ -142,7 +142,7 @@ download it again like so.
 
    $ {command} key pull 12EE233B
 
-   1 key(s) added to keyring of trust /home/dave/.singularity/sypgp/pgp-public
+   1 key(s) added to keyring of trust /home/dave/.{command}/sypgp/pgp-public
 
 But note that this only restores the *public* key (used for verifying)
 to your local machine and does not restore the *private* key (used for
@@ -233,7 +233,7 @@ offline with ``{command} key pull``
 
    $ {command} key pull E5F780B2C22F59DF748524B435C3844412EE233B
 
-   1 key(s) added to keyring of trust /home/dave/.singularity/sypgp/pgp-public
+   1 key(s) added to keyring of trust /home/dave/.{command}/sypgp/pgp-public
 
 Advanced Signing - SIF IDs and Groups
 =====================================

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -16,7 +16,7 @@ intended it.
 
    To verify containers signed with Singularity versions older than
    3.6.0 the ``--legacy-insecure`` flag must be provided to the
-   ``singularity verify`` command.
+   ``{command} verify`` command.
 
 .. _verify_container_from_library:
 
@@ -38,7 +38,7 @@ follow these steps:
    #. Enter a name for your new access token, such as "test token"
    #. Click the "Create a New Access Token" button.
    #. Click "Copy token to Clipboard" from the "New API Token" page.
-   #. Run ``singularity remote login`` and paste the access token at the
+   #. Run ``{command} remote login`` and paste the access token at the
       prompt.
 
 Now you can verify containers that you pull from the library, ensuring
@@ -46,7 +46,7 @@ they are bit-for-bit reproductions of the original image.
 
 .. code::
 
-   $ singularity verify alpine_latest.sif
+   $ {command} verify alpine_latest.sif
 
    Container is signed by 1 key(s):
 
@@ -78,7 +78,7 @@ command group like so:.
 
 .. code::
 
-   $ singularity key newpair
+   $ {command} key newpair
 
    Enter your name (e.g., John Doe) : David Trudgian
    Enter your email address (e.g., john.doe@example.com) : david.trudgian@sylabs.io
@@ -91,8 +91,8 @@ command group like so:.
 
 Note that I chose ``Y`` when asked if I wanted to push my key to the
 keystore. This will push my public key to whichever keystore has been
-configured by the ``singularity remote`` command, so that it can be
-retrieved by other users running ``singularity verify``. If you do not
+configured by the ``{command} remote`` command, so that it can be
+retrieved by other users running ``{command} verify``. If you do not
 wish to push your public key, say ``n`` during the ``newpair`` process.
 
 The ``list`` subcommand will show you all of the keys you have created
@@ -100,7 +100,7 @@ or saved locally.`
 
 .. code::
 
-   $ singularity key list
+   $ {command} key list
 
    Public key listing (/home/dave/.singularity/sypgp/pgp-public):
 
@@ -120,11 +120,11 @@ for the following:
 
 If you chose not to push your key to the keystore during the ``newpair``
 process, but later wish to, you can push it to a keystore configured
-using ``singularity remote`` like so:
+using ``{command} remote`` like so:
 
 .. code::
 
-   $ singularity key push E5F780B2C22F59DF748524B435C3844412EE233B
+   $ {command} key push E5F780B2C22F59DF748524B435C3844412EE233B
 
    public key `E5F780B2C22F59DF748524B435C3844412EE233B` pushed to server successfully
 
@@ -133,14 +133,14 @@ download it again like so.
 
 .. code::
 
-   $ singularity key search Trudgian
+   $ {command} key search Trudgian
 
    Showing 1 results
 
    KEY ID    BITS  NAME/EMAIL
    12EE233B  4096  David Trudgian (demo) <david.trudgian@sylabs.io>
 
-   $ singularity key pull 12EE233B
+   $ {command} key pull 12EE233B
 
    1 key(s) added to keyring of trust /home/dave/.singularity/sypgp/pgp-public
 
@@ -161,16 +161,16 @@ example:
 .. code::
 
    # search for key ID:
-   $ singularity key search 0x8883491F4268F173C6E5DC49EDECE4F3F38D871E
+   $ {command} key search 0x8883491F4268F173C6E5DC49EDECE4F3F38D871E
 
    # search for the sort ID:
-   $ singularity key search 0xF38D871E
+   $ {command} key search 0xF38D871E
 
    # search for user:
-   $ singularity key search Godlove
+   $ {command} key search Godlove
 
    # search for email:
-   $ singularity key search @gmail.com
+   $ {command} key search @gmail.com
 
 Signing and validating your own containers
 ==========================================
@@ -180,7 +180,7 @@ so:
 
 .. code::
 
-   $ singularity sign my_container.sif
+   $ {command} sign my_container.sif
 
    Signing image: my_container.sif
    Enter key passphrase :
@@ -191,7 +191,7 @@ without needing to contact the Keystore.
 
 .. code::
 
-   $ singularity verify my_container.sif
+   $ {command} verify my_container.sif
    Verifying image: my_container.sif
    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
@@ -210,9 +210,9 @@ command again.
 
 .. code::
 
-   $ singularity key remove E5F780B2C22F59DF748524B435C3844412EE233B
+   $ {command} key remove E5F780B2C22F59DF748524B435C3844412EE233B
 
-   $ singularity verify my_container.sif
+   $ {command} verify my_container.sif
    Verifying image: my_container.sif
    [REMOTE]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
    [REMOTE]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
@@ -227,11 +227,11 @@ command again.
 Note that the ``[REMOTE]`` message shows the key used for verification
 was obtained from the keystore, and is not present on your local
 computer. You can retrieve it, so that you can verify even if you are
-offline with ``singularity key pull``
+offline with ``{command} key pull``
 
 .. code::
 
-   $ singularity key pull E5F780B2C22F59DF748524B435C3844412EE233B
+   $ {command} key pull E5F780B2C22F59DF748524B435C3844412EE233B
 
    1 key(s) added to keyring of trust /home/dave/.singularity/sypgp/pgp-public
 
@@ -246,7 +246,7 @@ of objects. Each object has an ``ID``, and belongs to a ``GROUP``.
 
 .. code::
 
-   $ singularity sif list my_container.sif
+   $ {command} sif list my_container.sif
 
    Container id: e455d2ae-7f0b-4c79-b3ef-315a4913d76a
    Created on:   2019-11-15 10:11:58 -0600 CST
@@ -264,12 +264,12 @@ option to ``sign`` and ``verify``.
 
 .. code::
 
-   $ singularity sign --sif-id 1 my_container.sif
+   $ {command} sign --sif-id 1 my_container.sif
    Signing image: my_container.sif
    Enter key passphrase :
    Signature created and applied to my_container.sif
 
-   $ singularity verify --sif-id 1 my_container.sif
+   $ {command} verify --sif-id 1 my_container.sif
    Verifying image: my_container.sif
    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
@@ -286,7 +286,7 @@ knowledge.
 
 .. code::
 
-   $ singularity verify my_container.sif
+   $ {command} verify my_container.sif
    Verifying image: my_container.sif
    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
@@ -299,7 +299,7 @@ I can sign a group of objects with the ``--group-id`` option to
 
 .. code::
 
-   $ singularity sign --groupid 1 my_container.sif
+   $ {command} sign --groupid 1 my_container.sif
    Signing image: my_container.sif
    Enter key passphrase :
    Signature created and applied to my_container.sif
@@ -310,7 +310,7 @@ the same ``--group-id`` option.
 
 .. code::
 
-   $ singularity verify --group-id 1 my_container.sif
+   $ {command} verify --group-id 1 my_container.sif
    Verifying image: my_container.sif
    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
@@ -328,7 +328,7 @@ specifying ``--group-id`` can also verify the container:
 
 .. code::
 
-   $ singularity verify my_container.sif
+   $ {command} verify my_container.sif
    Verifying image: my_container.sif
    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -1,4 +1,4 @@
-.. _singularity-and-docker:
+.. _{command}-and-docker:
 
 #######################################
  Support for Docker and OCI Containers
@@ -44,7 +44,7 @@ the container that's called ``sylabsio/lolcow:latest``:
 
 .. code::
 
-   $ singularity run docker://sylabsio/lolcow:latest
+   $ {command} run docker://sylabsio/lolcow:latest
    INFO:    Converting OCI blobs to SIF format
    INFO:    Starting build...
    Getting image source signatures
@@ -72,11 +72,11 @@ creates a SIF file from them. This SIF file is kept in your
 Docker container again the downloads and conversion aren't required.
 
 To obtain the Docker container as a SIF file in a specific location,
-which you can move, share, and keep for later, ``singularity pull`` it:
+which you can move, share, and keep for later, ``{command} pull`` it:
 
 .. code::
 
-   $ singularity pull docker://sylabsio/lolcow
+   $ {command} pull docker://sylabsio/lolcow
    INFO:    Using cached SIF image
 
    $ ls -l lolcow_latest.sif
@@ -88,9 +88,9 @@ from the cache.
 
 .. note::
 
-   ``singularity pull`` of a Docker container actually runs a
-   ``singularity build`` behind the scenes, since we are translating
-   from OCI to SIF. If you ``singularity pull`` a Docker container
+   ``{command} pull`` of a Docker container actually runs a
+   ``{command} build`` behind the scenes, since we are translating
+   from OCI to SIF. If you ``{command} pull`` a Docker container
    twice, the output file isn't identical because metadata such as dates
    from the conversion will vary. This differs from pulling a SIF
    container (e.g. from a ``library://`` URI), which always give you an
@@ -106,9 +106,9 @@ check whether the container has been modified there. On shared systems,
 and when running containers in parallel, this can quickly exhaust the
 Docker Hub API limits.
 
-We recommend that you ``singularity pull`` a Docker image to a local
+We recommend that you ``{command} pull`` a Docker image to a local
 SIF, and then always run from the SIF file, rather than using
-``singularity run docker://...`` repeatedly.
+``{command} run docker://...`` repeatedly.
 
 Alternatively, if you have signed up for a Docker Hub account, make sure
 that you authenticate before using ``docker://`` container URIs.
@@ -123,30 +123,30 @@ a number of ways to do this with {Project}.
 {Project} CLI Remote Command
 ------------------------------
 
-The ``singularity remote login`` command supports logging into Docker
+The ``{command} remote login`` command supports logging into Docker
 Hub and other OCI registries. For Docker Hub, the registry hostname is
 ``docker.io``, so you will need to login as below, specifying your
 username:
 
 .. code::
 
-   $ singularity remote login --username myuser docker://docker.io
+   $ {command} remote login --username myuser docker://docker.io
    Password / Token:
-   INFO:    Token stored in /home/myuser/.singularity/remote.yaml
+   INFO:    Token stored in /home/myuser/.{command}/remote.yaml
 
 The Password / Token you enter must be a Docker Hub CLI access token,
 which you should generate in the 'Security' section of your account
 profile page on Docker Hub.
 
 To check which Docker / OCI registries you are currently logged in to,
-use ``singularity remote list``.
+use ``{command} remote list``.
 
 To logout of a registry, so that your credentials are forgotten, use
-``singularity remote logout``:
+``{command} remote logout``:
 
 .. code::
 
-   $ singularity remote logout docker://docker.io
+   $ {command} remote logout docker://docker.io
    INFO:    Logout succeeded
 
 Docker CLI Authentication
@@ -172,7 +172,7 @@ credentials, use the ``--docker-login`` flag:
 
 .. code::
 
-   $ singularity pull --docker-login docker://sylabsio/private
+   $ {command} pull --docker-login docker://sylabsio/private
    Enter Docker Username: myuser
    Enter Docker Password:
 
@@ -193,7 +193,7 @@ credentials.
 
    $ export APPTAINER_DOCKER_USERNAME=myuser
    $ export APPTAINER_DOCKER_PASSWORD=mytoken
-   $ singularity pull docker://sylabsio/private
+   $ {command} pull docker://sylabsio/private
 
 **********************************
  Containers From Other Registries
@@ -220,12 +220,12 @@ just include the ``quay.io`` hostname in your ``docker://`` URI:
 
 .. code::
 
-   $ singularity pull docker://quay.io/bitnami/python:3.7
+   $ {command} pull docker://quay.io/bitnami/python:3.7
    INFO:    Converting OCI blobs to SIF format
    INFO:    Starting build...
    ...
 
-   $ singularity run python_3.7.sif
+   $ {command} run python_3.7.sif
    Python 3.7.12 (default, Sep 24 2021, 11:48:27)
    [GCC 8.3.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
@@ -235,7 +235,7 @@ To pull containers from private repositories you will need to generate a
 CLI token in the Quay web interface, then use it to login with
 {Project}. Use the same methods as described for Docker Hub above:
 
--  Run ``singularity remote login --username myuser docker://quay.io``
+-  Run ``{command} remote login --username myuser docker://quay.io``
    to store your credentials for {Project}.
 -  Use ``docker login quay.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
@@ -256,7 +256,7 @@ login:
 
 .. code::
 
-   $ singularity pull docker://nvcr.io/nvidia/pytorch:21.09-py3
+   $ {command} pull docker://nvcr.io/nvidia/pytorch:21.09-py3
    INFO:    Converting OCI blobs to SIF format
    INFO:    Starting build...
 
@@ -268,7 +268,7 @@ Use one of the following authentication methods (detailed above for
 Docker Hub), with the username ``$oauthtoken`` and the password set to
 your NGC API key.
 
--  Run ``singularity remote login --username \$oauthtoken
+-  Run ``{command} remote login --username \$oauthtoken
    docker://nvcr.io`` to store your credentials for {Project}.
 -  Use ``docker login nvcr.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
@@ -287,7 +287,7 @@ public container from GitHub Container Registry using a ``ghcr.io`` URI:
 
 .. code::
 
-   $ singularity pull docker://ghcr.io/containerd/alpine:latest
+   $ {command} pull docker://ghcr.io/containerd/alpine:latest
    INFO:    Converting OCI blobs to SIF format
    INFO:    Starting build...
 
@@ -300,7 +300,7 @@ documentation here.
 Use one of the following authentication methods (detailed above for
 Docker Hub), with your username and personal access token:
 
--  Run ``singularity remote login --username myuser docker://ghcr.io``
+-  Run ``{command} remote login --username myuser docker://ghcr.io``
    to store your credentials for {Project}.
 -  Use ``docker login ghcr.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
@@ -334,7 +334,7 @@ username used in conjunction with this password is always ``AWS``.
 
 Then login using one of the following methods:
 
--  Run ``singularity remote login --username AWS
+-  Run ``{command} remote login --username AWS
    docker://<accountid>.dkr.ecr.<region>.amazonaws.com`` to store your
    credentials for {Project}.
 
@@ -367,7 +367,7 @@ will add credentials to ``.docker/config.json`` which can be read by
 Service Principle accounts will have an explicit username and password,
 and you should authenticate using one of the following methods:
 
--  Run ``singularity remote login --username myuser
+-  Run ``{command} remote login --username myuser
    docker://myregistry.azurecr.io`` to store your credentials for
    {Project}.
 
@@ -414,12 +414,12 @@ Docker Hub is the default registry, so when building from Docker Hub the
 ``From:`` header only needs to specify the container repository and
 tag:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: ubuntu:20.04
 
-If you ``singularity build`` a definition file with these lines,
+If you ``{command} build`` a definition file with these lines,
 {Project} will fetch the ``ubuntu:20.04`` container image from
 Docker Hub, and extract it as the basis for your new container.
 
@@ -430,12 +430,12 @@ To pull from a different Docker registry, you can either specify the
 hostname in the ``From:`` header, or use the separate ``Registry:``
 header. The following two examples are equivalent:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    From: quay.io/bitnami/python:3.7
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker
    Registry: quay.io
@@ -456,15 +456,15 @@ stored credentials or environment variables must be available to the
 ``root`` user:
 
 -  Use the ``--docker-login`` flag for a one-time interactive login.
-   I.E. run ``sudo singularity build --docker-login myimage.sif
+   I.E. run ``sudo {command} build --docker-login myimage.sif
    {Project}``.
 
 -  Set the ``APPTAINER_DOCKER_USERNAME`` and
    ``APPTAINER_DOCKER_PASSWORD`` environment variables. Pass the
    environment variables through sudo to the ``root`` build process by
-   running ``sudo -E singularity build ...``.
+   running ``sudo -E {command} build ...``.
 
--  Run ``sudo singularity remote login ...`` to store your credentials
+-  Run ``sudo {command} remote login ...`` to store your credentials
    for the ``root`` user on your system. This is separate from storing
    the credentials under your own account.
 
@@ -502,7 +502,7 @@ name:
 
 .. code::
 
-   $ singularity build lolcow_from_docker_cache.sif docker-daemon://sylabsio/lolcow:latest
+   $ {command} build lolcow_from_docker_cache.sif docker-daemon://sylabsio/lolcow:latest
    INFO:    Starting build...
    Getting image source signatures
    Copying blob sha256:a2022691bf950a72f9d2d84d557183cb9eee07c065a76485f1695784855c5193
@@ -539,7 +539,7 @@ registry, the ``docker-daemon`` bootstrap agent will not try to pull a
 To build from an image cached by the Docker daemon in a definition file
 use ``Bootstrap: docker-daemon``, and a ``From: <REPOSITORY>:TAG`` line:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker-daemon
    From: sylabsio/lolcow:latest
@@ -581,14 +581,14 @@ the layers and metadata that make up a Docker container:
    -rw-r--r--  0 0      0   118356480 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/layer.tar
    -rw-r--r--  0 0      0         266 Dec 31  1969 manifest.json
 
-We can convert this tar file into a singularity container using the
+We can convert this tar file into a {command} container using the
 ``docker-archive`` bootstrap agent. Because the agent accesses a file,
 rather than an object hosted by a service, it uses ``:<filename>``, not
 ``://<location>``. To build a tar archive directly to a SIF container:
 
 .. code::
 
-   $ singularity build lolcow_tar.sif docker-archive:lolcow.tar
+   $ {command} build lolcow_tar.sif docker-archive:lolcow.tar
    INFO:    Starting build...
    Getting image source signatures
    Copying blob sha256:2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171
@@ -611,7 +611,7 @@ To build an image using a definition file, which starts from a container
 in a Docker archive, use ``Bootstrap: docker-archive`` and specify the
 filename in the ``From:`` line:
 
-.. code:: singularity
+.. code:: {command}
 
    Bootstrap: docker-archive
    From: lolcow.tar
@@ -723,7 +723,7 @@ project directory that you need access to.
 
    # Without --contain, python in the container finds packages
    # in your $HOME directory.
-   $ singularity exec docker://python:3.9 pip list
+   $ {command} exec docker://python:3.9 pip list
    Package    Version
    ---------- -------
    pip        21.2.4
@@ -733,7 +733,7 @@ project directory that you need access to.
 
    # With --contain, python in the container only finds packages
    # installed in the container.
-   $ singularity exec --contain docker://python:3.9 pip list
+   $ {command} exec --contain docker://python:3.9 pip list
    Package    Version
    ---------- -------
    pip        21.2.4
@@ -757,14 +757,14 @@ are set in the container:
 
    # Set a host variable
    $ export HOST_VAR=123
-   # Set a singularity container environment variable
+   # Set a {command} container environment variable
    $ export "APPTAINERENV_FORCE_VAR="123"
 
-   $ singularity run library://alpine env | grep VAR
+   $ {command} run library://alpine env | grep VAR
    FORCE_VAR=123
    HOST_VAR=ABC
 
-   $ singularity run --cleanenv library://alpine env | grep VAR
+   $ {command} run --cleanenv library://alpine env | grep VAR
    FORCE_VAR=123
 
 Any environment variables set via an ``ENV`` line in a ``Dockerfile`` will be
@@ -846,12 +846,12 @@ around this, use the ``--no-init`` flag to disable the shim:
 
 .. code::
 
-   $ singularity run --pid tini_example.sif
+   $ {command} run --pid tini_example.sif
    [WARN  tini (2690)] Tini is not running as PID 1 .
    Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
    To fix the problem, run Tini as PID 1.
 
-   $ singularity run --pid --no-init tini_example.sif
+   $ {command} run --pid --no-init tini_example.sif
    ...
    # NO WARNINGS
 
@@ -898,7 +898,7 @@ used to build it, along with any arguments on the command line. The
 ``CMD`` and ``ENTRYPOINT`` can also be overridden by flags.
 
 A {Project} container has the concept of a *runscript*, which is a
-single shell script defining what happens when you ``singularity run``
+single shell script defining what happens when you ``{command} run``
 the container. Because there is no internal concept of ``CMD`` and
 ``ENTRYPOINT``, {Project} must create a runscript from the ``CMD``
 and ``ENTRYPOINT`` when converting a Docker container. The behavior of
@@ -912,11 +912,11 @@ is run, with any arguments appended:
    # ENTRYPOINT="date"
 
    # Runs 'date'
-   $ singularity run mycontainer.sif
+   $ {command} run mycontainer.sif
    Wed 06 Oct 2021 02:42:54 PM CDT
 
    # Runs 'date --utc`
-   $ singularity run mycontainer.sif --utc
+   $ {command} run mycontainer.sif --utc
    Wed 06 Oct 2021 07:44:27 PM UTC
 
 If the Docker container only has a ``CMD`` - the ``CMD`` is run, or is
@@ -927,11 +927,11 @@ If the Docker container only has a ``CMD`` - the ``CMD`` is run, or is
    # CMD="date"
 
    # Runs 'date'
-   $ singularity run mycontainer.sif
+   $ {command} run mycontainer.sif
    Wed 06 Oct 2021 02:45:39 PM CDT
 
    # Runs 'echo hello'
-   $ singularity run mycontainer.sif echo hello
+   $ {command} run mycontainer.sif echo hello
    hello
 
 If the Docker container has a ``CMD`` *and* ``ENTRYPOINT``, then we run
@@ -944,15 +944,15 @@ with any user supplied arguments:
    # CMD="--utc"
 
    # Runs 'date --utc'
-   $ singularity run mycontainer.sif
+   $ {command} run mycontainer.sif
    Wed 06 Oct 2021 07:48:43 PM UTC
 
    # Runs 'date -R'
-   $ singularity run mycontainer.sif -R
+   $ {command} run mycontainer.sif -R
    Wed, 06 Oct 2021 14:49:07 -0500
 
 There is no flag to override an ``ENTRYPOINT`` set for a Docker
-container. Instead, use ``singularity exec`` to run an arbitrary program
+container. Instead, use ``{command} exec`` to run an arbitrary program
 inside a container.
 
 Argument Handling
@@ -969,10 +969,10 @@ quoting of arguments.
    $ docker run -it --rm alpine echo "\$HOSTNAME"
    $HOSTNAME
 
-   $ singularity run docker://alpine echo "\$HOSTNAME"
+   $ {command} run docker://alpine echo "\$HOSTNAME"
    p700
 
-   $ singularity run docker://alpine echo "\\\$HOSTNAME"
+   $ {command} run docker://alpine echo "\\\$HOSTNAME"
    $HOSTNAME
 
 If you are running a binary inside a ``docker://`` container directly,
@@ -1055,10 +1055,10 @@ Registry Authentication Issues
 ==============================
 
 If you experience problems pulling containers from a private registry,
-check your credentials carefully. You can ``singularity pull`` with the
+check your credentials carefully. You can ``{command} pull`` with the
 ``--docker-login`` flag to perform an interactive login. This may be
 useful if you are unsure whether you have stored credentials properly
-via ``singularity remote login`` or ``docker login``.
+via ``{command} remote login`` or ``docker login``.
 
 OCI registries expect different values for username and password fields.
 Some require a token to be generated and used instead of your account
@@ -1163,7 +1163,7 @@ Section          Description                 Section          Description
 
 ``%runscript```  | Commands that will
                  | be run when you           ``ENTRYPOINT``   | Commands / arguments
-                 | ``singularity run``       ``CMD``          | that will run in the
+                 | ``{command} run``       ``CMD``          | that will run in the
                  | the container image.                       | container image.
 
 ``%startscript`` | Commands that will


### PR DESCRIPTION
This renames lower case `singularity` to `{command}`.  It includes renaming the pygments lexer from singularity to apptainer, because that is required because the way it is invoked is changed to `{command}`.  It also renames singularity_and_docker to docker_and_oci.  The first commit is basically a combination of the commits from #41.

- Fixes #17 
- Completes and replaces #41