### PR TITLE
Change github org+repo to {orgrepo}

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -794,9 +794,9 @@ Notes
 Arch Linux is, by design, a very stripped down, light-weight OS. You may
 need to perform a significant amount of configuration to get a usable
 OS. Please refer to this `README.md
-<https://github.com/singularityware/singularity/blob/master/examples/arch/README.md>`_
+<https://github.com/{orgrepo}/blob/master/examples/arch/README.md>`_
 and the `Arch Linux example
-<https://github.com/singularityware/singularity/blob/master/examples/arch/{Project}>`_
+<https://github.com/{orgrepo}/blob/master/examples/arch/>`_
 for more info.
 
 .. _build-busybox:

--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Singularity Container documentation build configuration file, created by
+# Apptainer documentation build configuration file, created by
 # sphinx-quickstart on Tue Aug 26 14:19:49 2014.
 #
 # This file is execfile()d with the current directory set to its
@@ -120,8 +120,8 @@ html_theme_options = {
 
 html_context = {
     'display_github': True,
-    'github_user': 'hpcng',
-    'github_repo': 'singularity-userdocs',
+    'github_user': 'apptainer',
+    'github_repo': 'apptainer-userdocs',
     'github_version': 'master',
     'conf_py_path': '/',
 }
@@ -202,7 +202,7 @@ html_show_copyright = False
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = '{command}-' + version + '-user-guide'
+htmlhelp_basename = 'apptainer-' + version + '-user-guide'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -222,7 +222,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'singularity-' + version + '-user-guide.tex', project, author, 'manual'),
+  ('index', 'apptainer-' + version + '-user-guide.tex', project, author, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -251,7 +251,7 @@ latex_logo = 'logo.png'
 
 # The title of the document. It defaults to the html_title option
 # but can be set independently for epub creation.
-epub_title = 'Singularity ' + version + ' User Guide'
+epub_title = 'Apptainer ' + version + ' User Guide'
 
 # The author of the document. This is put in the Dublin Core metadata.
 # It defaults to the author option.
@@ -266,7 +266,7 @@ epub_publisher = author
 epub_copyright = copyright
 
 # The basename for the epub file. It defaults to the project name.
-epub_basename = '{command}-' + version + '-user-guide'
+epub_basename = 'apptainer-' + version + '-user-guide'
 
 # The HTML theme for the epub output.
 # Since the default themes are not optimized for small screen space,
@@ -276,7 +276,7 @@ epub_theme = 'epub'
 
 # The unique identifier of the text. This can be a ISBN number
 # or the project homepage.
-epub_identifier = 'https://github.com/hpcng/singularity-userdocs'
+epub_identifier = 'https://github.com/apptainer/apptainer-userdocs'
 
 # The publication scheme for the epub_identifier. This is put in the Dublin Core metadata.
 # For published books the scheme is 'ISBN'. If you use the project homepage, 'URL' seems reasonable.

--- a/contributing.rst
+++ b/contributing.rst
@@ -41,7 +41,7 @@ find us at `apptainer
 ****************
 
 For general bugs/issues, you can open an issue `at the GitHub repo
-<https://github.com/apptainer/apptainer/issues/new>`_. However, if you
+<https://github.com/{orgrepo}/issues/new>`_. However, if you
 find a security related issue/problem, please email the {Project} Security Team directly at
 security@apptainer.org. More information about the {Project} security policies
 and procedures can be found `here
@@ -58,11 +58,11 @@ want to share the love so nobody feels left out!
 
 You can contribute to the documentation by `raising an issue to suggest
 an improvement
-<https://github.com/apptainer/apptainer-userdocs/issues/new>`_ or by
+<https://github.com/{orgrepo}-userdocs/issues/new>`_ or by
 sending a `pull request
-<https://github.com/apptainer/apptainer-userdocs/compare>`_ on `our
+<https://github.com/{orgrepo}-userdocs/compare>`_ on `our
 repository for documentation
-<https://github.com/apptainer/apptainer-userdocs>`_.
+<https://github.com/{orgrepo}-userdocs>`_.
 
 The current documentation is generated with:
 
@@ -77,7 +77,7 @@ Other dependencies include:
 More information about contributing to the documentation, instructions
 on how to install the dependencies, and how to generate the files can be
 obtained `here
-<https://github.com/apptainer/apptainer-userdocs/blob/master/README.md>`__.
+<https://github.com/{orgrepo}-userdocs/blob/master/README.md>`__.
 
 For more information on using Git and GitHub to create a pull request
 suggesting additions and edits to the docs, see the :ref:`section on
@@ -96,15 +96,15 @@ that you fork the main repo, create a new branch to make changes, and
 submit a pull request (PR) to the master branch.
 
 Check out our official `CONTRIBUTING.md
-<https://github.com/apptainer/apptainer/blob/master/CONTRIBUTING.md>`_
+<https://github.com/{orgrepo}/blob/master/CONTRIBUTING.md>`_
 document, which also includes a `code of conduct
-<https://github.com/apptainer/apptainer/blob/master/CONTRIBUTING.md#code-of-conduct>`_.
+<https://github.com/{orgrepo}/blob/master/CONTRIBUTING.md#code-of-conduct>`_.
 
 Step 1. Fork the repo
 =====================
 
 To contribute to {Project}, you should obtain a GitHub account and
-fork the `{Project} <https://github.com/apptainer/apptainer>`_
+fork the `{Project} <https://github.com/{orgrepo}>`_
 repository. Once forked, clone your fork of the repo to your computer.
 (Obviously, you should replace ``your-username`` with your GitHub
 username.)
@@ -203,7 +203,7 @@ you need to update a branch, you will need to follow the next steps:
 
 .. code::
 
-   $ git remote add upstream https://github.com/apptainer/apptainer.git && # to add a new remote named "upstream" \
+   $ git remote add upstream https://github.com/{orgrepo}.git && # to add a new remote named "upstream" \
        git checkout master && # or another branch to be updated \
        git pull upstream master && \
        git push origin master && # to update your fork \

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -34,7 +34,7 @@ A {Project} Definition file is divided into two parts:
    to be executed at runtime can accept options intended for ``/bin/sh``
 
 For more in-depth and practical examples of def files, see the `{Project}
-examples repository <https://github.com/apptainer/apptainer/tree/master/examples>`_
+examples repository <https://github.com/{orgrepo}/tree/master/examples>`_
 
 For a comparison between Dockerfile and {Project} definition file,
 please see: :ref:`this section <sec:deffile-vs-dockerfile>`.

--- a/plugins.rst
+++ b/plugins.rst
@@ -119,9 +119,9 @@ operation requires root privilege.
 
 Developers interested in writing {Project} plugins can get started
 by reading the `Go documentation
-<https://godoc.org/github.com/sylabs/singularity/pkg/plugin>`_ for the
+<https://godoc.org/github.com/{orgrepo}/pkg/plugin>`_ for the
 plugin package. Furthermore, reading through the `source code
-<https://github.com/hpcng/singularity/tree/master/examples/plugins>`_
+<https://github.com/{orgrepo}/tree/master/examples/plugins>`_
 for the example plugins will prove valuable. More detailed plugin
 development documentation is in the works and will be released at a
 future date.

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -133,14 +133,14 @@ Download {Project} from a release
 
 You can download {Project} from one of the releases. To see a full
 list, visit `the GitHub release page
-<https://github.com/apptainer/apptainer/releases>`_. After deciding on a
+<https://github.com/{orgrepo}/releases>`_. After deciding on a
 release to install, you can run the following commands to proceed with
 the installation.
 
 .. code::
 
    $ export VERSION={InstallationVersion} && # adjust this as necessary \
-       wget https://github.com/apptainer/apptainer/releases/download/v${VERSION}/{command}-${VERSION}.tar.gz && \
+       wget https://github.com/{orgrepo}/releases/download/v${VERSION}/{command}-${VERSION}.tar.gz && \
        tar -xzf {command}-${VERSION}.tar.gz && \
        cd {command}-${VERSION}
 
@@ -228,7 +228,7 @@ subcommands as follows:
      $ {command} help instance start
 
 
-   For additional help or support, please visit https://www.sylabs.io/docs/
+   For additional help or support, please visit https://www.apptainer.org/docs/
 
 Information about subcommand can also be viewed with the ``help``
 command.
@@ -264,7 +264,7 @@ command.
      $ {command} verify container.sif
 
 
-   For additional help or support, please visit https://www.sylabs.io/docs/
+   For additional help or support, please visit https://www.apptainer.org/docs/
 
 {Project} uses positional syntax (i.e. the order of commands and
 options matters). Global options affecting the behavior of all commands

--- a/replacements.py
+++ b/replacements.py
@@ -19,6 +19,7 @@ variable_replacements = {
     "{Project}": "Apptainer",
     "{command}": "apptainer",
     "{ENVPREFIX}": "APPTAINER",
+    "{orgrepo}": "apptainer/apptainer",
 }
 
 

--- a/running_services.rst
+++ b/running_services.rst
@@ -378,7 +378,7 @@ curl:
 
 .. code::
 
-   $ curl -o sylabs.pdf localhost:9000/api/render?url=http://sylabs.io/docs
+   $ curl -o apptainer.pdf localhost:9000/api/render?url=http://apptainer.org/docs
 
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                             Dload  Upload   Total   Spent    Left  Speed


### PR DESCRIPTION
This replaces github.com organization + repository references to singularity to use the replacement `{orgrepo}` instead.  It also fixes some problems found in conf.py, some from #54.

- Fixes #30
- Replaces and completes #51