### PR TITLE
Change remaining APPTAINER to {ENVPREFIX}

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,10 @@ jobs:
 
       - name: Lint rst
         run: |
-          rstcheck --ignore-language c,c++ --report warning *.rst
+          set -x
+          python3 copyreplace.py *.rst
+          rstcheck --ignore-language c,c++ --report warning *.rep
+          rm -f *.rep
 
       - name: Build web documentation
         run: |

--- a/contributing.rst
+++ b/contributing.rst
@@ -29,8 +29,7 @@ help out other users!
 ======================
 
 Many of our users come to Slack for quick help with an issue. You can
-find us at `apptainer
-<https://apptainer.slack.com/>`_.
+join through the `apptainer help page <https://apptainer.org/help/>`_.
 
 .. _contributing-to-documentation:
 

--- a/copyreplace.py
+++ b/copyreplace.py
@@ -1,0 +1,16 @@
+#
+# This copies all files given in argv to the same file name with a '.rep'
+#  extension, replacing all the strings defined in replacements.py.
+#  This is intended for use in conjunction with rstcheck which runs
+#  independently of the variable replacement that sphinx does.
+#
+from replacements import *
+import sys
+
+for f in sys.argv[1:]:
+    with open(f, 'r', encoding='utf-8') as fdin:
+        data = fdin.read()
+        for key in variable_replacements:
+            data = data.replace(key, variable_replacements[key])
+        with open(f + '.rep', 'w', encoding='utf-8') as fdout:
+            fdout.write(data)

--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -185,14 +185,14 @@ environment variables. These are often the default way of passing
 secrets into jobs within CI pipelines.
 
 {Project} accepts a username, and password / token, as
-``APPTAINER_DOCKER_USERNAME`` and ``APPTAINER_DOCKER_PASSWORD``
+``{ENVPREFIX}_DOCKER_USERNAME`` and ``{ENVPREFIX}_DOCKER_PASSWORD``
 respectively. These environment variables will override any stored
 credentials.
 
 .. code::
 
-   $ export APPTAINER_DOCKER_USERNAME=myuser
-   $ export APPTAINER_DOCKER_PASSWORD=mytoken
+   $ export {ENVPREFIX}_DOCKER_USERNAME=myuser
+   $ export {ENVPREFIX}_DOCKER_PASSWORD=mytoken
    $ {command} pull docker://sylabsio/private
 
 **********************************
@@ -239,8 +239,8 @@ CLI token in the Quay web interface, then use it to login with
    to store your credentials for {Project}.
 -  Use ``docker login quay.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
--  Set the ``APPTAINER_DOCKER_USERNAME`` and
-   ``APPTAINER_DOCKER_PASSWORD`` environment variables.
+-  Set the ``{ENVPREFIX}_DOCKER_USERNAME`` and
+   ``{ENVPREFIX}_DOCKER_PASSWORD`` environment variables.
 
 NVIDIA NGC
 ==========
@@ -272,8 +272,8 @@ your NGC API key.
    docker://nvcr.io`` to store your credentials for {Project}.
 -  Use ``docker login nvcr.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
--  Set the ``APPTAINER_DOCKER_USERNAME="\$oauthtoken"`` and
-   ``APPTAINER_DOCKER_PASSWORD`` environment variables.
+-  Set the ``{ENVPREFIX}_DOCKER_USERNAME="\$oauthtoken"`` and
+   ``{ENVPREFIX}_DOCKER_PASSWORD`` environment variables.
 
 See also:
 https://docs.nvidia.com/ngc/ngc-private-registry-user-guide/index.html
@@ -304,8 +304,8 @@ Docker Hub), with your username and personal access token:
    to store your credentials for {Project}.
 -  Use ``docker login ghcr.io`` if ``docker`` is on your machine.
 -  Use the ``--docker-login`` flag for a one-time interactive login.
--  Set the ``APPTAINER_DOCKER_USERNAME`` and
-   ``APPTAINER_DOCKER_PASSWORD`` environment variables.
+-  Set the ``{ENVPREFIX}_DOCKER_USERNAME`` and
+   ``{ENVPREFIX}_DOCKER_PASSWORD`` environment variables.
 
 AWS ECR
 =======
@@ -344,8 +344,8 @@ Then login using one of the following methods:
 
 -  Use the ``--docker-login`` flag for a one-time interactive login.
 
--  Set the ``APPTAINER_DOCKER_USERNAME=AWS`` and
-   ``APPTAINER_DOCKER_PASSWORD`` environment variables.
+-  Set the ``{ENVPREFIX}_DOCKER_USERNAME=AWS`` and
+   ``{ENVPREFIX}_DOCKER_PASSWORD`` environment variables.
 
 You should now be able to pull containers from your ECR URI at
 ``docker://<accountid>.dkr.ecr.<region>.amazonaws.com``.
@@ -376,8 +376,8 @@ and you should authenticate using one of the following methods:
 
 -  Use the ``--docker-login`` flag for a one-time interactive login.
 
--  Set the ``APPTAINER_DOCKER_USERNAME`` and
-   ``APPTAINER_DOCKER_PASSWORD`` environment variables.
+-  Set the ``{ENVPREFIX}_DOCKER_USERNAME`` and
+   ``{ENVPREFIX}_DOCKER_PASSWORD`` environment variables.
 
 The recent repository-scoped access token preview may be more
 convenient. See the `preview documentation
@@ -459,8 +459,8 @@ stored credentials or environment variables must be available to the
    I.E. run ``sudo {command} build --docker-login myimage.sif
    {Project}``.
 
--  Set the ``APPTAINER_DOCKER_USERNAME`` and
-   ``APPTAINER_DOCKER_PASSWORD`` environment variables. Pass the
+-  Set the ``{ENVPREFIX}_DOCKER_USERNAME`` and
+   ``{ENVPREFIX}_DOCKER_PASSWORD`` environment variables. Pass the
    environment variables through sudo to the ``root`` build process by
    running ``sudo -E {command} build ...``.
 
@@ -750,7 +750,7 @@ change the behaviour of software.
 
 To disable automatic propagation of environment variables, the
 ``--cleanenv / -e`` flag can be specified. When ``--cleanenv`` is used,
-only variables on the host that are prefixed with ``APPTAINERENV_``
+only variables on the host that are prefixed with ``{ENVPREFIX}ENV_``
 are set in the container:
 
 .. code::
@@ -758,7 +758,7 @@ are set in the container:
    # Set a host variable
    $ export HOST_VAR=123
    # Set a {command} container environment variable
-   $ export "APPTAINERENV_FORCE_VAR="123"
+   $ export "{ENVPREFIX}ENV_FORCE_VAR="123"
 
    $ {command} run library://alpine env | grep VAR
    FORCE_VAR=123
@@ -769,7 +769,7 @@ are set in the container:
 
 Any environment variables set via an ``ENV`` line in a ``Dockerfile`` will be
 available when the container is run with {Project}. You can override them
-with ``APPTAINERENV_`` vars, or the ``--env / --env-file`` flags, but they
+with ``{ENVPREFIX}ENV_`` vars, or the ``--env / --env-file`` flags, but they
 will not be overridden by host environment variables.
 
 For example, the ``docker://openjdk:latest`` container sets ``JAVA_HOME``:
@@ -785,7 +785,7 @@ For example, the ``docker://openjdk:latest`` container sets ``JAVA_HOME``:
    /usr/java/openjdk-17
 
    # Override JAVA_HOME in the container
-   export APPTAINERENV_JAVA_HOME=/test
+   export {ENVPREFIX}ENV_JAVA_HOME=/test
    $ {command} run docker://openjdk:latest echo \$JAVA_HOME
    /test
 

--- a/encryption.rst
+++ b/encryption.rst
@@ -46,9 +46,9 @@ build time via an environment variable or a command line option.
 +------------------------+-------------------------------------------+--------------------------+
 | **Encryption Method**  | **Environment Variable**                  | **Commandline Option**   |
 +------------------------+-------------------------------------------+--------------------------+
-| Passphrase             | ``APPTAINER_ENCRYPTION_PASSPHRASE``       | ``--passphrase``         |
+| Passphrase             | ``{ENVPREFIX}_ENCRYPTION_PASSPHRASE``       | ``--passphrase``         |
 +------------------------+-------------------------------------------+--------------------------+
-| Asymmetric Key (PEM)   | ``APPTAINER_ENCRYPTION_PEM_PATH``         | ``--pem-path``           |
+| Asymmetric Key (PEM)   | ``{ENVPREFIX}_ENCRYPTION_PEM_PATH``         | ``--pem-path``           |
 +------------------------+-------------------------------------------+--------------------------+
 
 The ``-e|--encrypt`` flag is implicitly set when the ``--passphrase`` or
@@ -58,8 +58,8 @@ following precedence is respected.
 
 #. ``--pem-path``
 #. ``--passphrase``
-#. ``APPTAINER_ENCRYPTION_PEM_PATH``
-#. ``APPTAINER_ENCRYPTION_PASSPHRASE``
+#. ``{ENVPREFIX}_ENCRYPTION_PEM_PATH``
+#. ``{ENVPREFIX}_ENCRYPTION_PASSPHRASE``
 
 Passphrase Encryption
 =====================
@@ -89,7 +89,7 @@ Using an environment variable
 
 .. code::
 
-   $ sudo APPTAINER_ENCRYPTION_PASSPHRASE=<secret> {command} build --encrypt encrypted.sif encrypted.def
+   $ sudo {ENVPREFIX}_ENCRYPTION_PASSPHRASE=<secret> {command} build --encrypt encrypted.sif encrypted.def
    Starting build...
 
 In this case it is necessary to use the ``--encrypt`` flag since the
@@ -104,7 +104,7 @@ like so.
 
 .. code::
 
-   $ export APPTAINER_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
+   $ export {ENVPREFIX}_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
 
    $ sudo -E {command} build --encrypt encrypted.sif encrypted.def
    Starting build...
@@ -153,7 +153,7 @@ Encrypting with an environment variable
 
 .. code::
 
-   $ sudo APPTAINER_ENCRYPTION_PEM_PATH=rsa_pub.pem {command} build --encrypt encrypted.sif encrypted.def
+   $ sudo {ENVPREFIX}_ENCRYPTION_PEM_PATH=rsa_pub.pem {command} build --encrypt encrypted.sif encrypted.def
    Starting build...
 
 In this case it is necessary to use the ``--encrypt`` flag since the
@@ -187,7 +187,7 @@ Running with a passphrase in an environment variable
 
 .. code::
 
-   $ APPTAINER_ENCRYPTION_PASSPHRASE="secret" {command} run encrypted.sif
+   $ {ENVPREFIX}_ENCRYPTION_PASSPHRASE="secret" {command} run encrypted.sif
 
 While this example shows how an environment variable can be used to set
 a passphrase, you should set the environment variable in a way that will
@@ -197,7 +197,7 @@ like so.
 
 .. code::
 
-   $ export APPTAINER_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
+   $ export {ENVPREFIX}_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
 
    $ {command} run encrypted.sif
 
@@ -219,4 +219,4 @@ Running using an environment variable
 
 .. code::
 
-   $ APPTAINER_ENCRYPTION_PEM_PATH=rsa_pri.pem {command} run encrypted.sif
+   $ {ENVPREFIX}_ENCRYPTION_PEM_PATH=rsa_pri.pem {command} run encrypted.sif

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -721,27 +721,27 @@ And the output would look like:
    OCI_CMD="bash"
    # ENTRYPOINT only - run entrypoint plus args
    if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
-   {ENVPREFIX}_OCI_RUN="${OCI_ENTRYPOINT} $@"
+   SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} $@"
    fi
 
    # CMD only - run CMD or override with args
    if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
    if [ $# -gt 0 ]; then
-       {ENVPREFIX}_OCI_RUN="$@"
+       SINGULARITY_OCI_RUN="$@"
    else
-       {ENVPREFIX}_OCI_RUN="${OCI_CMD}"
+       SINGULARITY_OCI_RUN="${OCI_CMD}"
    fi
    fi
 
    # ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
    # override with user provided args
    if [ $# -gt 0 ]; then
-       {ENVPREFIX}_OCI_RUN="${OCI_ENTRYPOINT} $@"
+       SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} $@"
    else
-       {ENVPREFIX}_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
+       SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
    fi
 
-   exec ${ENVPREFIX}_OCI_RUN
+   exec $SINGULARITY_OCI_RUN
 
 ``-t`` / ``--test``
 -------------------

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -40,11 +40,11 @@ environment variables that the program sees are a combination of:
 
    -  Any variables you set specifically for the container at runtime,
       using the ``--env``, ``--env-file`` options, or by setting
-      ``APPTAINERENV_`` variables outside of the container.
+      ``{ENVPREFIX}ENV_`` variables outside of the container.
 
    -  The ``PATH`` variable can be manipulated to add entries.
 
-   -  Runtime variables ``APPTAINER_xxx`` set by {Project} to
+   -  Runtime variables ``{ENVPREFIX}_xxx`` set by {Project} to
       provide information about the container.
 
 The environment variables from the base image or definition file used to
@@ -87,7 +87,7 @@ If I build a {command} container from the image
 This happens because the ``Dockerfile`` used to build that container has
 ``ENV PYTHON_VERSION 3.7.7`` set inside it.
 
-You can override the inherited environment with ``APPTAINERENV_`` vars, or the
+You can override the inherited environment with ``{ENVPREFIX}ENV_`` vars, or the
 ``--env / --env-file`` flags (see below), but ``Dockerfile`` ``ENV`` vars will
 not be overridden by host environment variables of the same name.
 
@@ -134,13 +134,13 @@ Build time variables in ``%post``
 In some circumstances the value that needs to be assigned to an
 environment variable may only be known after e.g. software
 installation, in ``%post``. For situations like this, the
-``$APPTAINER_ENVIRONMENT`` variable is provided. Redirecting text to
+``${ENVPREFIX}_ENVIRONMENT`` variable is provided. Redirecting text to
 this variable will cause it to be written to a file called
 ``/.singularity.d/env/91-environment.sh`` that will be sourced at
 runtime.
 
 Variables set in the ``%post`` section through
-``$APPTAINER_ENVIRONMENT`` take precedence over those added via
+``${ENVPREFIX}_ENVIRONMENT`` take precedence over those added via
 ``%environment``.
 
 ***************************
@@ -153,7 +153,7 @@ Except that:
 
    -  An environment variable set on the host will be overridden by a variable
       of the same name that has been set either inside the container image, or
-      via ``APPTAINERENV_`` environment variables, or the ``--env`` and
+      via ``{ENVPREFIX}ENV_`` environment variables, or the ``--env`` and
       ``--env-file`` flags.
 
    -  The ``PS1`` shell prompt is reset for a container specific prompt.
@@ -166,13 +166,13 @@ Except that:
       libraries if applicable.
 
 To override an environment variable that is already set in the container with
-the value from the host, use ``APPTAINERENV_`` or the ``--env`` flag. For
+the value from the host, use ``{ENVPREFIX}ENV_`` or the ``--env`` flag. For
 example, to force ``MYVAR`` in the container to take the value of ``MYVAR`` on
 the host:
 
 .. code::
 
-   $ export APPTAINERENV_MYVAR="$MYVAR"
+   $ export {ENVPREFIX}ENV_MYVAR="$MYVAR"
    $ {command} run mycontainer.sif
 
    # or
@@ -193,10 +193,10 @@ environment variables for correct operation of most software.
    PROMPT_COMMAND=PS1="{Project}> "; unset PROMPT_COMMAND
    PS1={Project}>
    PWD=/home/dave/doc-tesrts
-   APPTAINER_COMMAND=exec
-   APPTAINER_CONTAINER=/home/dave/doc-tesrts/env.sif
-   APPTAINER_ENVIRONMENT=/.singularity.d/env/91-environment.sh
-   APPTAINER_NAME=env.sif
+   {ENVPREFIX}_COMMAND=exec
+   {ENVPREFIX}_CONTAINER=/home/dave/doc-tesrts/env.sif
+   {ENVPREFIX}_ENVIRONMENT=/.singularity.d/env/91-environment.sh
+   {ENVPREFIX}_NAME=env.sif
    TERM=xterm-256color
 
 .. warning::
@@ -218,18 +218,18 @@ environment. {Project} will automatically set a number of
 environment variables in a container that can be inspected by any
 program running in the container.
 
-   -  ``APPTAINER_COMMAND`` - how the container was started, e.g.
+   -  ``{ENVPREFIX}_COMMAND`` - how the container was started, e.g.
       ``exec`` / ``run`` / ``shell``.
 
-   -  ``APPTAINER_CONTAINER`` - the full path to the container image.
+   -  ``{ENVPREFIX}_CONTAINER`` - the full path to the container image.
 
-   -  ``APPTAINER_ENVIRONMENT`` - path inside the container to the
+   -  ``{ENVPREFIX}_ENVIRONMENT`` - path inside the container to the
       shell script holding the container image environment settings.
 
-   -  ``APPTAINER_NAME`` - name of the container image, e.g.
+   -  ``{ENVPREFIX}_NAME`` - name of the container image, e.g.
       ``myfile.sif`` or ``docker://ubuntu``.
 
-   -  ``APPTAINER_BIND`` - a list of bind paths that the user
+   -  ``{ENVPREFIX}_BIND`` - a list of bind paths that the user
       requested, via flags or environment variables, when running the
       container.
 
@@ -275,11 +275,11 @@ environment variables as ``NAME=VALUE`` pairs, e.g.:
    $ {command} run --env-file myenvs env.sif
    Hello from a file
 
-``APPTAINERENV_`` prefix
+``{ENVPREFIX}ENV_`` prefix
 ==========================
 
 If you export an environment variable on your host called
-``APPTAINERENV_xxx`` *before* you run a container, then it will set
+``{ENVPREFIX}ENV_xxx`` *before* you run a container, then it will set
 the environment variable ``xxx`` inside the container:
 
 .. code::
@@ -287,7 +287,7 @@ the environment variable ``xxx`` inside the container:
    $ {command} run env.sif
    Hello
 
-   $ export APPTAINERENV_MYVAR="Overridden"
+   $ export {ENVPREFIX}ENV_MYVAR="Overridden"
    $ {command} run env.sif
    Overridden
 
@@ -321,10 +321,10 @@ setting ``PATH`` in the container definition ``%environment`` block.
 
 If your container depends on things that are bind mounted into it, or
 you have another need to modify the ``PATH`` variable when starting a
-container, you can do so with ``APPTAINERENV_APPEND_PATH`` or
-``APPTAINERENV_PREPEND_PATH``.
+container, you can do so with ``{ENVPREFIX}ENV_APPEND_PATH`` or
+``{ENVPREFIX}ENV_PREPEND_PATH``.
 
-If you set a variable on your host called ``APPTAINERENV_APPEND_PATH``
+If you set a variable on your host called ``{ENVPREFIX}ENV_APPEND_PATH``
 then its value will be appended (added to the end) of the ``PATH``
 variable in the container.
 
@@ -333,7 +333,7 @@ variable in the container.
    $ {command} exec env.sif sh -c 'echo $PATH'
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-   $ export APPTAINERENV_APPEND_PATH="/endpath"
+   $ export {ENVPREFIX}ENV_APPEND_PATH="/endpath"
    $ {command} exec env.sif sh -c 'echo $PATH'
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/endpath
 
@@ -341,7 +341,7 @@ Alternatively you could use the ``--env`` option to set a
 ``APPEND_PATH`` variable, e.g. ``--env APPEND_PATH=/endpath``.
 
 If you set a variable on your host called
-``APPTAINERENV_PREPEND_PATH`` then its value will be prepended (added
+``{ENVPREFIX}ENV_PREPEND_PATH`` then its value will be prepended (added
 to the start) of the ``PATH`` variable in the container.
 
 .. code::
@@ -349,7 +349,7 @@ to the start) of the ``PATH`` variable in the container.
    $ {command} exec env.sif sh -c 'echo $PATH'
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-   $ export APPTAINERENV_PREPEND_PATH="/startpath"
+   $ export {ENVPREFIX}ENV_PREPEND_PATH="/startpath"
    $ {command} exec env.sif sh -c 'echo $PATH'
    /startpath:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -449,7 +449,7 @@ When a container is run with {Project}, the container
 environment is constructed in the following order:
 
    -  Clear the environment, keeping just ``HOME`` and
-      ``APPTAINER_APPNAME``.
+      ``{ENVPREFIX}_APPNAME``.
    -  Set Docker/OCI defined environment variables, where a Docker or
       OCI image was used as the base for the container build.
    -  If ``PATH`` is not defined set the {Project} default ``PATH``
@@ -461,11 +461,11 @@ environment is constructed in the following order:
       override any previously set values.
    -  Set environment variables that were defined in the ``%post``
       section of the build, by addition to the
-      ``$APPTAINER_ENVIRONMENT`` file.
+      ``${ENVPREFIX}_ENVIRONMENT`` file.
    -  Set SCIF (``--app``) environment variables
    -  Set base environment essential vars (``PS1`` and
       ``LD_LIBRARY_PATH``)
-   -  Inject ``APPTAINERENV_`` / ``--env`` / ``--env-file`` variables
+   -  Inject ``{ENVPREFIX}ENV_`` / ``--env`` / ``--env-file`` variables
       so they can override or modify any previous values.
    -  Apply special ``APPEND_PATH`` / ``PREPEND_PATH`` handling.
    -  Restore environment variables from the host, if they have not
@@ -479,7 +479,7 @@ environment is constructed in the following order:
    recommended to avoid manipulating the container environment by
    directly adding or modifying scripts in this directory. Please use
    the ``%environment`` section of the definition file, and the
-   ``$APPTAINER_ENVIRONMENT`` file from ``%post`` if required.
+   ``${ENVPREFIX}_ENVIRONMENT`` file from ``%post`` if required.
 
    A future version of {Project} may move container scripts,
    environment, and metadata outside of the container's root
@@ -579,7 +579,7 @@ when you are writing the definition file, but can be obtained in the
 building.
 
 {Project} allows this, through adding labels to the
-file defined by the ``APPTAINER_LABELS`` environment variable in the
+file defined by the ``{ENVPREFIX}_LABELS`` environment variable in the
 ``%post`` section:
 
 .. code:: {command}
@@ -594,7 +594,7 @@ file defined by the ``APPTAINER_LABELS`` environment variable in the
    # We can now also set labels to a value at build time
    %post
      VAL="$(myprog --version)"
-     echo "my.label $VAL" >> "$APPTAINER_LABELS"
+     echo "my.label $VAL" >> "${ENVPREFIX}_LABELS"
 
 Labels must be added to the file one per line, in a ``NAME VALUE``
 format, where the name and value are separated by a space.
@@ -676,7 +676,7 @@ And the output would look like:
        touch .condarc
 
    %post
-       echo 'export RANDOM=123456' >>$APPTAINER_ENVIRONMENT
+       echo 'export RANDOM=123456' >>${ENVPREFIX}_ENVIRONMENT
        #Installing all dependencies
        apt-get update && apt-get -y upgrade
        apt-get -y install \
@@ -721,27 +721,27 @@ And the output would look like:
    OCI_CMD="bash"
    # ENTRYPOINT only - run entrypoint plus args
    if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
-   APPTAINER_OCI_RUN="${OCI_ENTRYPOINT} $@"
+   {ENVPREFIX}_OCI_RUN="${OCI_ENTRYPOINT} $@"
    fi
 
    # CMD only - run CMD or override with args
    if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
    if [ $# -gt 0 ]; then
-       APPTAINER_OCI_RUN="$@"
+       {ENVPREFIX}_OCI_RUN="$@"
    else
-       APPTAINER_OCI_RUN="${OCI_CMD}"
+       {ENVPREFIX}_OCI_RUN="${OCI_CMD}"
    fi
    fi
 
    # ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
    # override with user provided args
    if [ $# -gt 0 ]; then
-       APPTAINER_OCI_RUN="${OCI_ENTRYPOINT} $@"
+       {ENVPREFIX}_OCI_RUN="${OCI_ENTRYPOINT} $@"
    else
-       APPTAINER_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
+       {ENVPREFIX}_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
    fi
 
-   exec $APPTAINER_OCI_RUN
+   exec ${ENVPREFIX}_OCI_RUN
 
 ``-t`` / ``--test``
 -------------------

--- a/gpu.rst
+++ b/gpu.rst
@@ -152,7 +152,7 @@ whether some or all host GPUs are visible inside a container. The
 container dependent on the value of ``NVIDIA_VISIBLE_DEVICES``.
 
 To control which GPUs are used in a {Project} container that is run
-with ``--nv`` you can set ``APPTAINERENV_CUDA_VISIBLE_DEVICES`` before
+with ``--nv`` you can set ``{ENVPREFIX}ENV_CUDA_VISIBLE_DEVICES`` before
 running the container, or ``CUDA_VISIBLE_DEVICES`` inside the container.
 This variable will limit the GPU devices that CUDA programs see.
 
@@ -161,11 +161,11 @@ the host, we could do:
 
 .. code::
 
-   $ APPTAINERENV_CUDA_VISIBLE_DEVICES=0 {command} run --nv tensorflow_latest-gpu.sif
+   $ {ENVPREFIX}ENV_CUDA_VISIBLE_DEVICES=0 {command} run --nv tensorflow_latest-gpu.sif
 
    # or
 
-   $ export APPTAINERENV_CUDA_VISIBLE_DEVICES=0
+   $ export {ENVPREFIX}ENV_CUDA_VISIBLE_DEVICES=0
    $ {command} run tensorflow_latest-gpu.sif
 
 Troubleshooting
@@ -303,7 +303,7 @@ When running with ``--nvccli``, by default {Project} will expose all
 GPUs on the host inside the container. This mirrors the functionality of
 the standard GPU support for the most common use-case.
 
-Setting the ``APPTAINER_CUDA_VISIBLE_DEVICES`` environment variable
+Setting the ``{ENVPREFIX}_CUDA_VISIBLE_DEVICES`` environment variable
 before running a container is still supported, to control which GPUs are
 used by CUDA programs that honor ``CUDA_VISIBLE_DEVICES``. However, more
 powerful GPU isolation is possible using the ``--contain`` (or ``-c``) flag and
@@ -320,7 +320,7 @@ on a system with 4 GPUs, run the following:
 
 Note that:
 
--  ``NVIDIA_VISIBLE_DEVICES`` is not prepended with ``APPTAINER_`` as
+-  ``NVIDIA_VISIBLE_DEVICES`` is not prepended with ``{ENVPREFIX}_`` as
    this variable controls container setup, and is not passed into the
    container.
 

--- a/running_services.rst
+++ b/running_services.rst
@@ -466,7 +466,7 @@ requests to the server:
            echo "Usage: {command} run --app pdf <instance://name> <URL> [output file]"
            exit 1
        fi
-       curl -o "${APPTAINER_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
+       curl -o "${{ENVPREFIX}_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
 
 As you can see, the ``pdf_client`` app checks to make sure that the user
 provides at least one argument.
@@ -514,7 +514,7 @@ The full def file will look like this:
            echo "Usage: {command} run --app pdf <instance://name> <URL> [output file]"
            exit 1
        fi
-       curl -o "${APPTAINER_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
+       curl -o "${{ENVPREFIX}_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
 
 Create the container as before. The ``--force`` option will overwrite
 the old container:


### PR DESCRIPTION
This changes remaining `APPTAINER` strings to `{ENVPREFIX}`.  It introduced a problem with rstcheck, so this also changes rstcheck to check the files after the replacements are applied.

- Fixes #47
- Continues #49