### PR TITLE
Fix CentOS 7 error with gpgme by including containers_image_openpgp tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+# containers_image_openpgp is needed at least on CentOS 7 because its
+#  gpgme package is too old
+GO_BUILD_TAGS = containers_image_openpgp
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -58,7 +61,7 @@ apptainer_source/builddir/apptainer:
 
 cli/apptainer.rst: apptainer_source/builddir/apptainer
 	cd apptainer_source &&\
-	go run ./cmd/docs rst --dir ../cli
+	go run -tags "$(GO_BUILD_TAGS)" ./cmd/docs rst --dir ../cli 
 
 endif
 


### PR DESCRIPTION
This fixes an error building the documentation CentOS 7 by avoiding needing to compile with the gpgme package.  Without this, the error there is:
```
$ make html
cd apptainer_source &&\
go run ./cmd/docs rst --dir ../cli
# github.com/proglottis/gpgme
/nashome/d/dwd/gopath/pkg/mod/github.com/proglottis/gpgme@v0.1.1/data.go:187:12: could not determine kind of name for C.gogpgme_data_seek
/nashome/d/dwd/gopath/pkg/mod/github.com/proglottis/gpgme@v0.1.1/data.go:53:53: could not determine kind of name for C.gpgme_off_t
cgo:
gcc errors for preamble:
In file included from /nashome/d/dwd/gopath/pkg/mod/github.com/proglottis/gpgme@v0.1.1/data.go:6:0:
./go_gpgme.h:15:1: error: unknown type name 'gpgme_off_t'
 extern gpgme_off_t gogpgme_data_seek(gpgme_data_t dh, gpgme_off_t offset, int whence);
 ^
./go_gpgme.h:15:55: error: unknown type name 'gpgme_off_t'
 extern gpgme_off_t gogpgme_data_seek(gpgme_data_t dh, gpgme_off_t offset, int whence);
                                                       ^

make: *** [cli/apptainer.rst] Error 2
```