### PR TITLE
Add link to restoring library behavior

### DIFF
--- a/endpoint.rst
+++ b/endpoint.rst
@@ -276,6 +276,7 @@ If you do not want to switch remote with ``remote use`` you can:
    ``--library`` option.
 -  Make ``keys`` use an alternative keyserver with the ``-url`` option.
 
+.. _restoring_pre-{command}_library_behavior:
 
 Restoring pre-{Project} library behavior
 ========================================
@@ -309,7 +310,7 @@ download from the Sylabs Cloud anonymously:
 
 To set the defaults system-wide see the corresponding section in the
 `admin guide
-<{admindocs}/configfiles.html#restoring-pre-apptainer-library-behavior>`_.
+<{admindocs}/configfiles.html#restoring-pre-{command}-library-behavior>`_.
 
 
 **************************

--- a/singularity_compatibility.rst
+++ b/singularity_compatibility.rst
@@ -149,3 +149,8 @@ migration again:
   {Project} will not migrate cached container data such as OCI blobs and SIF
   images. User caches will need to be manually migrated or reconstructed through
   normal use of {Project}.
+
+The default remote configuration has changed in {Project}, so if you did
+not previously set any remotes and want to continue to use the previous
+default for ``library://`` and/or pgp keys, see
+:ref:`Restoring pre-{Project} library behavior <restoring_pre-{command}_library_behavior>`.


### PR DESCRIPTION
This adds a paragraph to the singularity compatibility page linking to the section on restoring the previous library behavior.