### PR TITLE
Fix --mount option typo (two hyphens), from sylabs 80 (1.0)

### DIFF
--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -194,7 +194,7 @@ Mount specifications are also read from then environment variable
 ``${ENVPREFIX}_MOUNT``. Multiple bind mounts set via this environment
 variable should be separated by newlines (``\n``).
 
-Using ``--bind`` or ``-mount`` with the ``--writable`` flag
+Using ``--bind`` or ``--mount`` with the ``--writable`` flag
 ===========================================================
 
 To mount a bind path inside the container, a *bind point* must be

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -195,7 +195,7 @@ Mount specifications are also read from then environment variable
 variable should be separated by newlines (``\n``).
 
 Using ``--bind`` or ``--mount`` with the ``--writable`` flag
-===========================================================
+============================================================
 
 To mount a bind path inside the container, a *bind point* must be
 defined within the container. The bind point is a directory within the


### PR DESCRIPTION
This cherry-picks #91 to the 1.0 branch