### PR TITLE
Remove `date` from apt-get install

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -648,7 +648,7 @@ Here is an example of a definition file:
 
    %post
        apt-get -y update
-       apt-get -y install date cowsay lolcat
+       apt-get -y install cowsay lolcat
 
    %environment
        export LC_ALL=C


### PR DESCRIPTION
`date` is a part of coreutils and not a separate apt-get package. As such, the build will fail with:

```
+ apt-get -y install date cowsay lolcat
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package date
FATAL:   While performing build: while running engine: exit status 100
```
Unless removed. The `date` user command is still available by default in the base ubuntu container, so everything else seems to work to build and run the run script.

Signed-off-by: Christopher Buckley <15166572+topherbuckley@users.noreply.github.com>

## Description of the Pull Request (PR):

Adding this cherry-picked patch as per [this discussion](https://github.com/apptainer/apptainer-userdocs/pull/89#issuecomment-1072487508) with @DrDaveD from main to 1.0 . 

## This fixes or addresses the following GitHub issues:

N/A
