### PR TITLE
Updates for 1.1.0-rc.3

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -351,6 +351,9 @@ below with their respective functionality.
 #. **{ENVPREFIX}_UNSHARE_UTS**: To specify that the container will run
    in a new UTS namespace. Default is set to false.
 
+#. **{ENVPREFIX}_UNSQUASH**: To convert SIF files to temporary sandboxes
+   before running a container. Default is set to false.
+
 #. **{ENVPREFIX}_UPDATE**: To run the definition over an existing
    container (skips the header). Default is set to false.
 

--- a/security.rst
+++ b/security.rst
@@ -96,9 +96,9 @@ However, there are also some disadvantages of the non-suid mode:
 
 -  Mounting from unprivileged user namespaces makes use of FUSE
    filesystems, which run extra processes in user space.
-   This has lower performance than kernel filesystems, but it is
-   believed to not be a very significant overhead for most HPC
-   workflows.
+   This has slightly lower performance than kernel filesystems,
+   but it is has been shown to not be a very significant overhead for
+   typical HPC workflows.
    Metadata operations are still moved to the node running the
    container, which is a big advantage over having many files directly
    on networked filesystems.


### PR DESCRIPTION
Add the APPTAINER_UNSQUASH variable and revise the reference to the performance of unprivileged SIF mounts, corresponding to release 1.1.0-rc.3.