### PR TITLE
Update for 1.1.2, show unprivileged groups

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -258,7 +258,7 @@ are on the host system.
    david
 
    {Project} lolcow_latest.sif:~> id
-   uid=1000(david) gid=1000(david) groups=1000(david),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare)
+   uid=1000(david) gid=1000(david) groups=1000(david),65534(nfsnobody)
 
 ``shell`` also works with the ``docker://``, ``oras://``, ``library://``,  and
 ``shub://`` URIs. This creates an ephemeral container that disappears

--- a/replacements.py
+++ b/replacements.py
@@ -12,7 +12,7 @@ def variableReplace(app, docname, source):
 # Add the needed variables to be replaced either on code or on text on the next
 # dictionary structure.
 variable_replacements = {
-    "{InstallationVersion}" : "1.1.0",
+    "{InstallationVersion}" : "1.1.2",
     "{admindocs}" : "https://apptainer.org/docs/admin/main",
     "{version}": "main",
     "{adminversion}": "main",


### PR DESCRIPTION
Update version to 1.1.2 and in quick_start show the groups that show when running unprivileged.