### PR TITLE
add 1.0 old version notice, from sylabs 111

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -x
           python3 copyreplace.py *.rst
-          rstcheck --ignore-language c,c++ --report warning *.rep
+          rstcheck --ignore-languages c,c++ --report-level warning *.rep
           rm -f *.rep
 
       - name: Build web documentation

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,11 @@
+{% extends "!layout.html" %}
+{%- block content %}
+<div class="rst-content style-external-links">
+    <div class="admonition warning">
+        <p class="admonition-title">Warning</p>
+        <p>You're browsing the documentation for an old version of Apptainer. Consider upgrading to the latest version of Apptainer.</p>
+        <p>Documentation for the latest version can always be found at: <br><a class="reference external" href="https://apptainer.org/docs/user/latest/">https://apptainer.org/docs/user/latest/</a></p>
+    </div>
+</div>
+{{ super() }}
+{% endblock %}


### PR DESCRIPTION
This pulls in sylabs PR
- sylabs/singularity-userdocs#111

The original PR description was:
> Add banner notice that state this is old documentation and add a robots.txt to prevent search engine indexing.