### PR TITLE
writable-tmpfs & overlay changes, from sylabs 147

### DIFF
--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -682,6 +682,13 @@ A writable overlay file in a SIF partition cannot be used in parallel.
 {Project} will refuse to run concurrently using the same SIF
 writable overlay partition.
 
+.. note::
+
+   The ``--writable-tmpfs`` size is controlled by ``sessiondir max size`` in
+   ``{command}.conf``. This defaults to 64MiB, and may need to be increased if
+   your workflows create larger temporary files.
+
+
 Dockerfile ``USER``
 ===================
 


### PR DESCRIPTION
This pulls in sylabs PR
- sylabs/singularity-userdocs#147
which fixed
- sylabs/singularity-userdocs#137
- sylabs/singularity-userdocs#138
- sylabs/singularity-userdocs#140
- sylabs/singularity-userdocs#146

The original PR description was:
> * --writable-tmpfs with kernel unpriv overlay
> * session dir max size implication
> * directory --overlay with kernel unpriv overlay
> * sparse overlay creation