### PR TITLE
Rewrite instances section, from sylabs 149

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Copyright (c) Contributors to the Apptainer project, established as
   Apptainer a Series of LF Projects LLC.
   - For website terms of use, trademark policy, privacy policy and other
      project policies see https://lfprojects.org/policies
-Copyright (c) 2018-2022, Sylabs, Inc. All rights reserved.
+Copyright (c) 2018-2023, Sylabs, Inc. All rights reserved.
 Copyright (c) 2017, SingularityWare, LLC. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cgroups.rst
+++ b/cgroups.rst
@@ -61,6 +61,8 @@ satisfy these criteria by default. On older distributions support can often be
 enabled. Consult the admin documentation or speak to your system administrator
 about this.
 
+.. _cgroup_flags:
+
 *************************
 Command Line Limit Flags
 *************************

--- a/index.rst
+++ b/index.rst
@@ -81,7 +81,7 @@ networking and security configuration.
 
    Bind Paths and Mounts <bind_paths_and_mounts>
    Persistent Overlays <persistent_overlays>
-   Running Services <running_services>
+   Instances - Running Services <running_services>
    Environment and Metadata <environment_and_metadata>
    Plugins <plugins>
    Security Options <security_options>


### PR DESCRIPTION
This pulls in sylabs PR
- sylabs/singularity-userdocs#149
which fixed
- sylabs/singularity-userdocs#143
- sylabs/singularity-userdocs#144
- sylabs/singularity-userdocs#145

The original PR description was:
> * Remove complex example with binds
> * Rewrite examples for preferred foreground mode of startscript process
> * Add details of instance logs
> * Add details of instance stats / cgroups limits
> * General edits