### PR TITLE
fix oras bootstrap agent example, from sylabs 126 (1.1)

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -600,7 +600,7 @@ module to use.
 
 .. code:: {command}
 
-   From: oras://registry/namespace/image:tag
+   From: registry/namespace/image:tag
 
 The ``From`` keyword is mandatory. It specifies the container to use as
 a base. Also,``tag`` is mandatory that refers to the version of image


### PR DESCRIPTION
This cherry-picks #163 to the 1.1 branch