### PR TITLE
Link cgroups to the admin security section (1.1)

### DIFF
--- a/cgroups.rst
+++ b/cgroups.rst
@@ -58,7 +58,8 @@ system must:
 
 Recent distributions such as Ubuntu 22.04, Debian 11, Fedora 31, and newer,
 satisfy these criteria by default. On older distributions support can often be
-enabled. Consult the admin documentation or speak to your system administrator
+enabled. Consult the `admin security documentation <{admindocs}/security.html>`_
+or speak to your system administrator
 about this.
 
 ***************************


### PR DESCRIPTION
This cherry-picks #175 to the 1.1 branch.