### PR TITLE
Insert replacement macros where they weren't being used

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -853,9 +853,9 @@ Notes
 Arch Linux is, by design, a very stripped down, light-weight OS. You may
 need to perform a significant amount of configuration to get a usable
 OS. Please refer to this `README.md
-<https://github.com/{orgrepo}/blob/master/examples/arch/README.md>`_
+<https://github.com/{orgrepo}/blob/{repobranch}/examples/arch/README.md>`_
 and the `Arch Linux example
-<https://github.com/{orgrepo}/blob/master/examples/arch/>`_
+<https://github.com/{orgrepo}/blob/{repobranch}/examples/arch/>`_
 for more info.
 
 .. _build-busybox:

--- a/contributing.rst
+++ b/contributing.rst
@@ -66,7 +66,7 @@ Other dependencies include:
 More information about contributing to the documentation, instructions
 on how to install the dependencies, and how to generate the files can be
 obtained `here
-<https://github.com/{orgrepo}-userdocs/blob/main/README.md>`__.
+<https://github.com/{orgrepo}-userdocs/blob/{repobranch}/README.md>`__.
 
 For more information on using Git and GitHub to create a pull request
 suggesting additions and edits to the docs, see the :ref:`section on
@@ -85,9 +85,9 @@ that you fork the main repo, create a new branch to make changes, and
 submit a pull request (PR) to the main branch.
 
 Check out our official `CONTRIBUTING.md
-<https://github.com/{orgrepo}/blob/main/CONTRIBUTING.md>`_
+<https://github.com/{orgrepo}/blob/{repobranch}/CONTRIBUTING.md>`_
 document, which also includes a `code of conduct
-<https://github.com/{orgrepo}/blob/main/CONTRIBUTING.md#code-of-conduct>`_.
+<https://github.com/{orgrepo}/blob/{repobranch}/CONTRIBUTING.md#code-of-conduct>`_.
 
 Step 1. Fork the repo
 =====================

--- a/encryption.rst
+++ b/encryption.rst
@@ -37,7 +37,7 @@ at runtime in memory.
    normal unprivileged users and decrypted either without a suid installion or with the ``--userns``
    option.  The partition type in a SIF image in this case will be shown as ``Gocryptfs squashfs``.
    This case requires 
-   `unprivileged user namespaces <https://apptainer.org/docs/admin/main/user_namespace.html>`_. 
+   `unprivileged user namespaces <{admindocs}/user_namespace.html>`_. 
 
 **********************
 Encrypting a container

--- a/plugins.rst
+++ b/plugins.rst
@@ -147,4 +147,4 @@ by reading the `Go documentation
 plugin package.
 
 Example plugins can be found in the {Project} `source code
-<https://github.com/{orgrepo}/tree/master/examples/plugins>`_.
+<https://github.com/{orgrepo}/tree/{repobranch}/examples/plugins>`_.


### PR DESCRIPTION
This puts in replacement macros where they weren't been used but should have been.