### PR TITLE
Make MPI UCX issue link work correctly (1.2)

### DIFF
--- a/mpi.rst
+++ b/mpi.rst
@@ -249,7 +249,7 @@ If the host MPI is Open MPI, the definition file looks like:
 
    The MPI UCX library has a problem with unprivileged user namespaces.
    See `apptainer issue 769
-   <https://github.com/apptainer/apptainer/issues/769 >`__
+   <https://github.com/apptainer/apptainer/issues/769>`__
    for details and for now use the ``UCX_TLS=sysv,ib`` transport as a
    workaround, for example:
 


### PR DESCRIPTION
This cherry-picks #210 to the 1.2 branch.