### PR TITLE
Show where to store images in the lima instance

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -216,6 +216,31 @@ supported by {Project}. To see a comparison of the {Project}
 definition file with Dockerfile, please see: :ref:`this section
 <sec:deffile-vs-dockerfile>`.
 
+.. note::
+
+   If you are using {Project} through Lima, be aware that the home
+   directory is mounted as read-only and cannot be used for writing.
+   You need to change to another directory (use ``cd``) to run those
+   commands, such as ``{command} pull`` or ``{command} build``, from
+   your ``lima`` shell::
+
+   $ limactl shell apptainer
+   $ cd /tmp/lima
+   $ {command} pull docker://alpine
+   $ exit
+
+   Otherwise you will get an error, about: "read-only file system"
+
+   You can also use an absolute path, to where you want the images.
+   The best performance is found when using a filesystem local to the
+   guest instance (instead of using a shared filesystem), but then you
+   need to copy the files from the guest to the host after building::
+
+   $ apptainer.lima build /var/tmp/alpine.sif docker://alpine
+   $ limactl copy apptainer:/var/tmp/alpine.sif ./alpine.sif
+
+   Now it can be used, since {Project} images are read-only by default.
+
 .. _cowimage:
 
 ***********************


### PR DESCRIPTION
## Description of the Pull Request (PR):

While it is possible to shell into the virtual machine, it is also possible to call apptainer.lima on the host.

This makes it easier to interact with the local files, and to copy the resulting SIF files to another location.

Currently this is not really showing the interaction from the host, since it is assumed to be "as normal".

Just details on where the images can be stored, in order to 1) be used in the guest 2) be used on the host

![apptainer-storage](https://github.com/apptainer/apptainer-userdocs/assets/10364051/f43dcda5-7ff3-418d-a9e5-c1e7d92fb814)


## This fixes or addresses the following GitHub issues:

* https://github.com/apptainer/apptainer-admindocs/pull/141

---

Unfortunately Sphinx doesn't like PS1, which makes the prompts somewhat confusing.

```console
anders@ubuntu:~$ lima
anders@lima-apptainer:/home/anders$ 
```

But hopefully people can sort it out anyway? It's not so different from when using `ssh`.

```console
anders@ubuntu:~$ ssh -F ~/.lima/apptainer/ssh.config lima-apptainer
anders@lima-apptainer:~$ 
```

### Notes

1) `limactl shell` is a command for ssh
1) `lima` is a shell wrapper for `limactl shell`
2) `apptainer.lima` is a shell wrapper for `lima apptainer`

So the end result is similar to running : `ssh lima-apptainer apptainer`, with variables.
The most useful one being APPTAINER_BINDPATH, for mounting `/Users/$USER` too.

In case you haven't seen Lima before, the "lima-apptainer" is a Linux Machine (LiMa)
Normally it is a VM running locally, but it _could_ be a physical server or a cloud server.