### PR TITLE
Update to go 1.20, install setuptools

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.6
+          go-version: 1.20.1
 
       - name: Update repositories
         run: |
@@ -42,7 +42,7 @@ jobs:
           # see https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
           # Once fixed, it can be removed from the list because it is
           # otherwise an implied dependency
-          pip install --user --upgrade --upgrade-strategy eager docutils==0.16 sphinx sphinx-rtd-theme restructuredtext_lint pygments m2r2
+          pip install --user --upgrade --upgrade-strategy eager docutils==0.16 setuptools sphinx sphinx-rtd-theme restructuredtext_lint pygments m2r2
 
       - name: Build web documentation
         run: |


### PR DESCRIPTION
This makes corresponding changes to #237 for the publish action.