### PR TITLE
update sample outputs of key list cmd to match singularity PR 1957, from sylabs 174 

### DIFF
--- a/definition_files.rst
+++ b/definition_files.rst
@@ -215,7 +215,7 @@ to one another during the build process.
        fi
 
    %labels
-       Author alice
+       Author myuser@example.com
        Version v0.0.1
 
    %help
@@ -691,7 +691,7 @@ Consider the ``%labels`` section from the example definition file above:
 .. code:: {command}
 
    %labels
-       Author d@sylabs.io
+       Author myuser@example.com
        Version v0.0.1
        MyLabel Hello World
 
@@ -701,7 +701,7 @@ first space will be taken as the label's name, and the portion following
 it will be taken as the label's value.
 
 In the previous example, the first label name is ``Author`` with a
-value of ``alice``. The second label name is ``Version`` with a
+value of ``myuser@example.com``. The second label name is ``Version`` with a
 value of ``v0.0.1``. Finally, the third label name is ``MyLabel`` with a
 value of ``Hello World``.
 
@@ -712,7 +712,7 @@ following command:
 
    $ {command} inspect my_container.sif
 
-   Author: alice
+   Author: myuser@example.com
    Version: v0.0.1
    MyLabel: Hello World
    org.label-schema.build-arch: amd64

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -53,16 +53,15 @@ The output will look as it follows:
 
    Private key listing (/home/joana/.{command}/keys/pgp-secret):
 
-   0) U: Johnny Cash (none) <cash@example.com>
-   C: 2019-04-11 22:22:28 +0200 CEST
-   F: 47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
-   L: 3072
-   --------
-   1) U: John Green (none) <john@example.com>
-   C: 2019-04-11 13:08:45 +0200 CEST
-   F: 5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
-   L: 1024
-   --------
+   0)  User:              Johnny Cash (none) <cash@sylabs.io>
+       Creation time:     2019-04-11 22:22:28 +0200 CEST
+       Fingerprint:       47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
+       Length (in bits):  3072
+
+   1)  User:              John Green (none) <john@sylabs.io>
+       Creation time:     2019-04-11 13:08:45 +0200 CEST
+       Fingerprint:       5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
+       Length (in bits):  1024
 
 .. note::
 
@@ -102,21 +101,20 @@ keystore by running ``{command} key list -s`` command:
 
    Private key listing (/home/joana/.{command}/keys/pgp-secret):
 
-     0) U: Johnny Cash (none) <cash@example.com>
-     C: 2019-04-11 22:22:28 +0200 CEST
-     F: 47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
-     L: 3072
-     --------
-     1) U: John Green (none) <john@example.com>
-     C: 2019-04-11 13:08:45 +0200 CEST
-     F: 5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
-     L: 1024
-     --------
-     3) U: Pinkie Pie (Eternal chaos comes with chocolate rain!) <balloons@example.com>
-     C: 2019-04-26 12:07:07 +0200 CEST
-     F: 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
-     L: 1024
-     --------
+   1)  User:              Johnny Cash (none) <cash@sylabs.io>
+       Creation time:     2019-04-11 22:22:28 +0200 CEST
+       Fingerprint:       47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
+       Length (in bits):  3072
+
+   2)  User:              John Green (none) <john@sylabs.io>
+       Creation time:     2019-04-11 13:08:45 +0200 CEST
+       Fingerprint:       5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
+       Length (in bits):  1024
+
+   3)  User:              Pinkie Pie (Eternal chaos comes with chocolate rain!) <balloons@sylabs.io>
+       Creation time:     2019-04-26 12:07:07 +0200 CEST
+       Fingerprint:       8C10B902F438E4D504C3ACF689FCFFAED5F34A77
+       Length (in bits):  1024
 
 You will see the imported key at the bottom of the list. Remember you
 can also import an ``ascii`` armored key and this will be automatically

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -53,12 +53,12 @@ The output will look as it follows:
 
    Private key listing (/home/joana/.{command}/keys/pgp-secret):
 
-   0)  User:              Johnny Cash (none) <cash@sylabs.io>
+   0)  User:              Johnny Cash (none) <cash@example.com>
        Creation time:     2019-04-11 22:22:28 +0200 CEST
        Fingerprint:       47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
        Length (in bits):  3072
 
-   1)  User:              John Green (none) <john@sylabs.io>
+   1)  User:              John Green (none) <john@example.com>
        Creation time:     2019-04-11 13:08:45 +0200 CEST
        Fingerprint:       5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
        Length (in bits):  1024
@@ -101,17 +101,17 @@ keystore by running ``{command} key list -s`` command:
 
    Private key listing (/home/joana/.{command}/keys/pgp-secret):
 
-   1)  User:              Johnny Cash (none) <cash@sylabs.io>
+   1)  User:              Johnny Cash (none) <cash@example.com>
        Creation time:     2019-04-11 22:22:28 +0200 CEST
        Fingerprint:       47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
        Length (in bits):  3072
 
-   2)  User:              John Green (none) <john@sylabs.io>
+   2)  User:              John Green (none) <john@example.com>
        Creation time:     2019-04-11 13:08:45 +0200 CEST
        Fingerprint:       5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
        Length (in bits):  1024
 
-   3)  User:              Pinkie Pie (Eternal chaos comes with chocolate rain!) <balloons@sylabs.io>
+   3)  User:              Pinkie Pie (Eternal chaos comes with chocolate rain!) <balloons@example.com>
        Creation time:     2019-04-26 12:07:07 +0200 CEST
        Fingerprint:       8C10B902F438E4D504C3ACF689FCFFAED5F34A77
        Length (in bits):  1024

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -90,9 +90,9 @@ You can use the ``newpair`` subcommand in the ``key`` command group like so:
 
    $ {command} key newpair
 
-   Enter your name (e.g., John Doe) : Ian Kaneshiro
-   Enter your email address (e.g., john.doe@example.com) : ikaneshiro@apptainer.org
-   Enter optional comment (e.g., development keys) : example key
+   Enter your name (e.g., John Doe) : Joe User
+   Enter your email address (e.g., john.doe@example.com) : myuser@example.com
+   Enter optional comment (e.g., development keys) : demo
    Enter a passphrase :
    Retype your passphrase :
    Generating Entity and OpenPGP Key Pair... done
@@ -106,9 +106,9 @@ or saved locally.
 
    Public key listing (/home/ian/.{command}/keys/pgp-public):
 
-   0)  User:              Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
-       Creation time:     2022-02-23 15:12:19 -0800 PST
-       Fingerprint:       8232570480B868E1473AEEB03DBCBA1EE9D661E5
+   0)  User:              Joe User (demo) <myuser@example.com>
+       Creation time:     2019-11-15 09:54:54 -0600 CST
+       Fingerprint:       E5F780B2C22F59DF748524B435C3844412EE233B
        Length (in bits):  4096
 
 If you would like others in the community to easily be able to fetch your
@@ -166,8 +166,8 @@ download it again like so.
 
    Showing 1 results
 
-   FINGERPRINT                               ALGORITHM  BITS  CREATION DATE                  EXPIRATION DATE  STATUS     NAME/EMAIL
-   8232570480B868E1473AEEB03DBCBA1EE9D661E5  RSA        4096  2022-02-23 15:12:19 -0800 PST                   [enabled]  Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
+   KEY ID    BITS  NAME/EMAIL
+   12EE233B  4096  Joe User (demo) <myuser@example.com>
 
    $ {command} key pull 8232570480B868E1473AEEB03DBCBA1EE9D661E5
    1 key(s) added to keyring of trust /home/ian/.{command}/keys/pgp-public
@@ -221,8 +221,8 @@ without needing to contact the key server.
    $ {command} verify my_container.sif
 
    Verifying image: my_container.sif
-   [LOCAL]   Signing entity: Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
-   [LOCAL]   Fingerprint: 8232570480B868E1473AEEB03DBCBA1EE9D661E5
+   [LOCAL]   Signing entity: Joe User (Demo keys) <myuser@example.com>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
    Objects verified:
    ID  |GROUP   |LINK    |TYPE
    ------------------------------------------------
@@ -244,8 +244,8 @@ command again.
    $ {command} verify my_container.sif
 
    Verifying image: my_container.sif
-   [REMOTE]  Signing entity: Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
-   [REMOTE]  Fingerprint: 8232570480B868E1473AEEB03DBCBA1EE9D661E5
+   [REMOTE]   Signing entity: Joe User (Demo keys) <myuser@example.com>
+   [REMOTE]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
    Objects verified:
    ID  |GROUP   |LINK    |TYPE
    ------------------------------------------------
@@ -307,8 +307,8 @@ option to ``sign`` and ``verify``.
    $ {command} verify --sif-id 1 my_container.sif
 
    Verifying image: my_container.sif
-   [LOCAL]   Signing entity: Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
-   [LOCAL]   Fingerprint: 8232570480B868E1473AEEB03DBCBA1EE9D661E5
+   [LOCAL]   Signing entity: Joe User (Demo keys) <myuser@example.com>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
    Objects verified:
    ID  |GROUP   |LINK    |TYPE
    ------------------------------------------------
@@ -325,8 +325,8 @@ knowledge.
    $ {command} verify my_container.sif
 
    Verifying image: my_container.sif
-   [LOCAL]   Signing entity: Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
-   [LOCAL]   Fingerprint: 8232570480B868E1473AEEB03DBCBA1EE9D661E5
+   [LOCAL]   Signing entity: Joe User (Demo keys) <myuser@example.com>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
 
    Error encountered during signature verification: object 2: object not signed
    FATAL:   Failed to verify container: integrity: object 2: object not signed
@@ -350,8 +350,8 @@ the same ``--group-id`` option.
    $ {command} verify --group-id 1 my_container.sif
 
    Verifying image: my_container.sif
-   [LOCAL]   Signing entity: Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
-   [LOCAL]   Fingerprint: 8232570480B868E1473AEEB03DBCBA1EE9D661E5
+   [LOCAL]   Signing entity: Joe User (Demo keys) <myuser@example.com>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
    Objects verified:
    ID  |GROUP   |LINK    |TYPE
    ------------------------------------------------
@@ -370,8 +370,8 @@ specifying ``--group-id`` can also verify the container:
    $ {command} verify my_container.sif
 
    Verifying image: my_container.sif
-   [LOCAL]   Signing entity: Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
-   [LOCAL]   Fingerprint: 8232570480B868E1473AEEB03DBCBA1EE9D661E5
+   [LOCAL]   Signing entity: Joe User (Demo keys) <myuser@example.com>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
    Objects verified:
    ID  |GROUP   |LINK    |TYPE
    ------------------------------------------------

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -106,19 +106,10 @@ or saved locally.
 
    Public key listing (/home/ian/.{command}/keys/pgp-public):
 
-   0) U: Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
-      C: 2022-02-23 15:12:19 -0800 PST
-      F: 8232570480B868E1473AEEB03DBCBA1EE9D661E5
-      L: 4096
-      --------
-
-In the output above the index of my key is ``0`` and the letters stand
-for the following:
-
-   -  U: User
-   -  C: Creation date and time
-   -  F: Fingerprint
-   -  L: Key length
+   0)  User:              Ian Kaneshiro (example key) <ikaneshiro@apptainer.org>
+       Creation time:     2022-02-23 15:12:19 -0800 PST
+       Fingerprint:       8232570480B868E1473AEEB03DBCBA1EE9D661E5
+       Length (in bits):  4096
 
 If you would like others in the community to easily be able to fetch your
 public key for image verification, you can push your key to a public keyserver.


### PR DESCRIPTION
This fixes a subpart of https://github.com/apptainer/apptainer-userdocs/issues/239 by merging
- https://github.com/sylabs/singularity-userdocs/pull/174
which fixed
- https://github.com/sylabs/singularity/pull/1957

The original PR description was:
> https://github.com/sylabs/singularity/pull/1957 changes the format of the output of singularity key list. This PR updates the sample outputs of this command contained in the User Guide to match this change.