### PR TITLE
Add missing space in table, from sylabs205

### DIFF
--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -1255,7 +1255,7 @@ Section          Description                 Section          Description
                  | build-time.                                | build-time.
 
 
-``%runscript```  | Commands that will
+``%runscript``   | Commands that will
                  | be run when you           ``ENTRYPOINT``   | Commands / arguments
                  | ``{command} run``         ``CMD``          | that will run in the
                  | the container image.                       | container image.


### PR DESCRIPTION
This fixes a subpart of #239 by importing
- sylabs/singularity-userdocs#205

The original PR description was
> Fixes missing space in the table at the end of singularity_and_docker.rst that was causing a "malformed table" error on compilation.

In our case the fix changes the last quote of a triple quote into a space.