### PR TITLE
Mention upgrade / uninstall docs are in admin guide, from sylabs 209

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -8,8 +8,8 @@ This guide aims to give an introduction to {Project}, brief
 installation instructions, and cover topics relevant to users building
 and running containers.
 
-For a detailed guide to installation and configuration, please see the
-separate `Admin Guide <{admindocs}>`_ for this version of {Project}.
+For a detailed guide to installation and configuration, as well as upgrading or
+uninstalling, please see the separate `Admin Guide <{admindocs}>`_ for this version of {Project}.
 
 ****************************************
 Getting Started & Background Information

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -37,7 +37,7 @@ are discussed in the `installation section of the admin guide
 <{admindocs}/installation.html>`__.
 
 If you have an existing version of {Project} installed from source, which
-you wish to upgrade or remove / uninstall, see the `installation section of the admin guide
+you wish to upgrade or remove / uninstall, also see the `installation section of the admin guide
 <{admindocs}/installation.html>`__.
 
 ***************************************

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -36,6 +36,10 @@ and using {Project} on Mac and Windows machines
 are discussed in the `installation section of the admin guide
 <{admindocs}/installation.html>`__.
 
+If you have an existing version of {Project} installed from source, which
+you wish to upgrade or remove / uninstall, see the `installation section of the admin guide
+<{admindocs}/installation.html>`__.
+
 ***************************************
 Overview of the {Project} Interface
 ***************************************
@@ -137,7 +141,6 @@ Information about individual subcommands can also be viewed by using the
 
    Examples:
      $ {command} verify container.sif
-
 
    For additional help or support, please visit https://www.apptainer.org/docs/
 


### PR DESCRIPTION
This fixes a subpart of https://github.com/apptainer/apptainer-userdocs/issues/239 by merging

- https://github.com/sylabs/singularity-userdocs/pull/209
which fixed
- https://github.com/sylabs/singularity-userdocs/issues/124

The original PR description was:
> Fixes https://github.com/sylabs/singularity-userdocs/issues/124