### PR TITLE
fix "tenth" (of a CPU) unit to "hundredth", from sylabs 212

### DIFF
--- a/cgroups.rst
+++ b/cgroups.rst
@@ -85,8 +85,8 @@ CPU Limits
 ==========
 
 ``--cpus`` sets the number of CPUs, or fractional CPUs, that the container can
-use.  The minimum is ``0.01`` or one tenth of a physical CPU. The maximum is the
-number of CPU cores on your system.
+use.  The minimum is ``0.01`` or one hundredth of a physical CPU. The maximum is
+the number of CPU cores on your system.
 
 .. code::
 


### PR DESCRIPTION
This fixes a subpart of https://github.com/apptainer/apptainer-userdocs/issues/239 by merging

- https://github.com/sylabs/singularity-userdocs/pull/212
which fixed
- https://github.com/sylabs/singularity-userdocs/issues/211

The original PR description was:

> Fixes incorrect unit (in prose) for description of CPU limit (--cpu option) from "tenth" to "hundredth".