### PR TITLE
encrypted containers can be built unprivileged

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -44,11 +44,9 @@ Container Signing & Encryption
 
 {Project} allows containers to be signed using a PGP key. The
 signature travels with the container image, allowing you to verify that
-the image is unmodified at any time. Encryption of containers using
-LUKS2 is also supported. Encrypted containers can be run without
+the image is unmodified at any time. Encryption of containers
+is also supported. Encrypted containers can be run without
 decrypting them to disk first.
-Using encrypted containers currently requires a setuid installation of
-{Project}.
 
 .. toctree::
    :maxdepth: 1

--- a/security_options.rst
+++ b/security_options.rst
@@ -107,9 +107,8 @@ this keyword.
 Building encrypted containers
 *****************************
 
-With {aProject} setuid installation it is possible to build and run
-encrypted containers.
-The containers are decrypted at runtime entirely in kernel space, meaning
+{Project} can build and run encrypted containers.
+The containers are decrypted at runtime entirely in memory, meaning
 that no intermediate decrypted data is ever present on disk. See
 :ref:`encrypted containers <encryption>` for more details.
 


### PR DESCRIPTION
These were also missed in the 1.2.0 release.