### PR TITLE
Use export in %environment to ensure variables are inherited by subprocesses

### DIFF
--- a/definition_files.rst
+++ b/definition_files.rst
@@ -567,7 +567,7 @@ the following syntax:
 .. code:: {command}
 
     %environment
-       FOO=${FOO:-'default'}
+       export FOO=${FOO:-'default'}
 
 The value of ``FOO`` in the container will take the value of ``FOO`` on
 the host, or ``default`` if ``FOO`` is not set on the host or if


### PR DESCRIPTION
Fix so there isn't an example for `%environment` without `export`, as sourcing that file won't make the variable available in subprocesses.  In current version of apptainer that seems to be the shell offered as well, so an unexported variable in `%environment` doesn't seem to be detectable.