### PR TITLE
Use export in %environment to ensure variables are inherited by subprocesses (1.3)

### DIFF
--- a/definition_files.rst
+++ b/definition_files.rst
@@ -567,7 +567,7 @@ the following syntax:
 .. code:: {command}
 
     %environment
-       FOO=${FOO:-'default'}
+       export FOO=${FOO:-'default'}
 
 The value of ``FOO`` in the container will take the value of ``FOO`` on
 the host, or ``default`` if ``FOO`` is not set on the host or if


### PR DESCRIPTION
Reflect https://github.com/apptainer/apptainer-userdocs/pull/267 for the 1.3 branch.
