### PR TITLE
Adding more clarity on how sigs are applied to objects.

### DIFF
--- a/signNverify.rst
+++ b/signNverify.rst
@@ -273,7 +273,7 @@ As well as the default behaviour, which signs all objects, fine-grained
 control of signing is possible.
 
 If you ``sif list`` a SIF file you will see it is comprised of a number
-of objects. Each object has an ``ID``, and belongs to a ``GROUP``.
+of objects. Each object has an ``ID``, and belongs to a ``GROUP``. Since signatures are *applied* to objects, they have an ``ID`` but not a ``GROUP``.
 
 .. code::
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Just 1 line clarifying why signatures do not have a group.


## This fixes or addresses the following GitHub issues:

- Fixes apptainer/apptainer#2159