### PR TITLE
fix: correct link to apptainer.org/support

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -14,7 +14,7 @@ If you need to request an installation on your shared resource, see
 information to send to your system administrator.
 
 For any additional help or support contact the {Project} Community:
-https://{command}.org/help
+https://{command}.org/support
 
 ************
 Installation


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes 404 to /help page which is actually /support