### PR TITLE
[DOC] Remove wildcard escape

### DIFF
--- a/running_services.rst
+++ b/running_services.rst
@@ -186,16 +186,11 @@ commands are identical.
 
 .. code::
 
-   $ {command} instance stop \*
+   $ {command} instance stop '*'
 
    $ {command} instance stop --all
 
    $ {command} instance stop -a
-
-.. note::
-
-   You must escape the wildcard with a backslash ``\*`` to pass it properly
-   through your shell.
 
 ************************************
 Nginx "Hello-world" in {Project}


### PR DESCRIPTION
## Description of the Pull Request (PR):

I propose surrounding the wildcard with ticks for the following reasons:

- Consistent with other examples on this page: https://github.com/apptainer/apptainer-userdocs/blob/f5392a7067433d9a55fa6fc0ec115422bfef8d22/running_services.rst?plain=1#L123
- No additional `note` needed
- Therefore hopefully helping less experienced users
