### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/appendix.rst
+++ b/appendix.rst
@@ -310,7 +310,7 @@ below with their respective functionality.
 #. **{ENVPREFIX}_NOCLEANUP**: To not clean up the bundle after a failed
    build, this can be helpful for debugging. Default is set to false.
 
-#. **{ENVPREFIX}_NOCOLOR**: Print mesages without color output.
+#. **{ENVPREFIX}_NOCOLOR**: Print messages without color output.
    Default is set to false unless stderr is not a terminal.
 
 #. **{ENVPREFIX}_NO_HTTPS** and **{ENVPREFIX}_NOHTTPS**: Set to true to use HTTP
@@ -1146,7 +1146,7 @@ written explicitly.
 Overview
 --------
 
-The ``docker-archive`` boostrap agent allows you to create a {Project} image
+The ``docker-archive`` bootstrap agent allows you to create a {Project} image
 from a docker image stored in a ``docker save`` formatted tar file:
 
 .. code:: console

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -76,7 +76,7 @@ Multiple system mounts can be disabled by specifying them separated by commas:
 When the administrator has configured custom ``bind path`` entries in
 ``{command}.conf``, to mount specific paths into the container by default, you
 can disable them individually. To do this, specify the path(s) to disable with
-the ``--no-mount`` flag. For example, if the adminstrator has configured
+the ``--no-mount`` flag. For example, if the administrator has configured
 ``{command}.conf`` to always mount ``/data2``. you can disable this with
 ``--no-mount /data2``:
 

--- a/build_env.rst
+++ b/build_env.rst
@@ -267,7 +267,7 @@ cannot be accessed in the ``%post`` section of a definition file. To pass values
 into a build, use the :ref:`templating / build-args support <sec:templating>`.
 
 Environment variables that control a build are generally associated with an
-equivalent CLI option. The order of precendence is:
+equivalent CLI option. The order of precedence is:
 
 #. If a flag is represented by both a CLI option and an environment variable,
    and both are set, the CLI option will take precedence. This is true for all

--- a/cgroups.rst
+++ b/cgroups.rst
@@ -178,7 +178,7 @@ IO Limits
 
 ``--blkio-weight`` sets a relative weight for the container when performing
 block I/O, e.g. reading/writing to/from disk. The weight should be between 10
-and 1000, and will control how much I/O access a container recieves when there
+and 1000, and will control how much I/O access a container receives when there
 is contention for I/O with other containers. It may be useful to give high
 priority to a container that needs infrequent but time sensitive data access,
 running alongside an application that is continuously performing bulk reads.

--- a/checkpoint.rst
+++ b/checkpoint.rst
@@ -13,7 +13,7 @@ containerized applications while they are executing and then restart them from
 the saved state.
 
 This is valuable for use cases that need to minimize the impact of ephemeral
-environment failures, random hardware failures or job premption.
+environment failures, random hardware failures or job preemption.
 
 .. note::
 

--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -477,7 +477,7 @@ will likely fail:
 However, {Project} is able to make use of CPU emulation with QEMU, and the Linux
 kernel's binfmt_misc mechanism, to run containers that do not match the host CPU.
 
-An adminstrator can configure emulation support by installing distribution
+An administrator can configure emulation support by installing distribution
 packages, or using the `multiarch/qemu-user-static
 <https://github.com/multiarch/qemu-user-static>`__ container from Docker Hub:
 
@@ -974,7 +974,7 @@ variables. To avoid the extra evaluation of variables that {Project}
 performs you can:
 
 * Follow the instructions in the :ref:`escaping-environment` section to
-  explictly escape environment variables.
+  explicitly escape environment variables.
 * Use the ``--no-eval`` flag.
 
 ``--no-eval`` prevents {Project} from evaluating environment variables on

--- a/encryption.rst
+++ b/encryption.rst
@@ -31,10 +31,10 @@ at runtime in memory.
 
    We use ``Privileged Encryption`` to represent the case of an encrypted image built by the
    root user and decrypted with a suid installation.  The partition type in a SIF image in this
-   case wil be shown as ``Encrypted squashfs``.
+   case will be shown as ``Encrypted squashfs``.
 
    We use ``Unprivileged Encryption`` to represent the case of an encrypted image built by
-   normal unprivileged users and decrypted either without a suid installion or with the ``--userns``
+   normal unprivileged users and decrypted either without a suid installation or with the ``--userns``
    option.  The partition type in a SIF image in this case will be shown as ``Gocryptfs squashfs``.
    This case requires 
    `unprivileged user namespaces <{admindocs}/user_namespace.html>`_. 

--- a/fakeroot.rst
+++ b/fakeroot.rst
@@ -236,7 +236,7 @@ Using fakeroot command inside definition file:
 
 When using fakeroot mode 3 above, where user namespaces are
 available but /etc/subuid mapping is not set up, and you are trying
-to build a container for an operating sytem with an older glibc
+to build a container for an operating system with an older glibc
 library than the host or for a target operating system like alpine
 that does not include glibc, this more advanced technique may help.
 

--- a/introduction.rst
+++ b/introduction.rst
@@ -141,7 +141,7 @@ There are various software packages which are so complicated that it
 takes much effort in order to port, update and qualify to new operating
 systems or compilers. The atmospheric and weather applications are a
 good example of this. Porting them to a contained operating system will
-prolong the usefullness of the development effort considerably.
+prolong the usefulness of the development effort considerably.
 
 Complicated work-flows that require custom installation and/or data
 ===================================================================

--- a/singularity_compatibility.rst
+++ b/singularity_compatibility.rst
@@ -54,7 +54,7 @@ We can see from the ``env`` output that this environment variable was properly
 set inside the container.
 
 Next we can use the ``SINGULARITYENV_`` prefix to do the same thing, but this
-time we wil have the intended value be ``BAZ``:
+time we will have the intended value be ``BAZ``:
 
 .. code::
 


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.