### PR TITLE
fix rst lint

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,9 +44,10 @@ jobs:
       - name: Lint rst
         run: |
           set -x
-          python3 copyreplace.py *.rst
-          rstcheck --ignore-languages c,c++ --report-level warning *.rep
-          rm -f *.rep
+          mkdir _tmp/
+          python3 copyreplace.py _tmp/ *.rst
+          rstcheck --ignore-languages c,c++ --report-level warning _tmp/*
+          rm -fr _tmp/
 
       - name: Build web documentation
         run: |

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext clidocs
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext clidocs lint
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -48,6 +48,7 @@ help:
 	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  lint       to run rstcheck on .rst files"
 
 ifndef SKIPCLI
 
@@ -194,3 +195,9 @@ pseudoxml: clidocs
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+lint:
+	mkdir _tmp/
+	python3 copyreplace.py _tmp/ *.rst
+	rstcheck --ignore-languages c,c++ --report-level warning _tmp/*
+	rm -fr _tmp/

--- a/copyreplace.py
+++ b/copyreplace.py
@@ -1,16 +1,20 @@
 #
-# This copies all files given in argv to the same file name with a '.rep'
+#  This copies all files given in argv to the same file name with a '.rep'
 #  extension, replacing all the strings defined in replacements.py.
 #  This is intended for use in conjunction with rstcheck which runs
 #  independently of the variable replacement that sphinx does.
 #
+
 from replacements import *
 import sys
+from pathlib import Path
 
-for f in sys.argv[1:]:
+output_dir = Path(sys.argv[1])
+
+for f in sys.argv[2:]:
     with open(f, 'r', encoding='utf-8') as fdin:
         data = fdin.read()
         for key in variable_replacements:
             data = data.replace(key, variable_replacements[key])
-        with open(f + '.rep', 'w', encoding='utf-8') as fdout:
+        with open(output_dir / f, 'w', encoding='utf-8') as fdout:
             fdout.write(data)

--- a/copyreplace.py
+++ b/copyreplace.py
@@ -1,10 +1,9 @@
 #
-#  This copies all files given in argv to the same file name with a '.rep'
-#  extension, replacing all the strings defined in replacements.py.
+#  This copies all files given in argv to the directory given by the
+#  first argument and replacing all the strings defined in replacements.py.
 #  This is intended for use in conjunction with rstcheck which runs
 #  independently of the variable replacement that sphinx does.
 #
-
 from replacements import *
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Description of the Pull Request (PR):

It seems to me that the Lint rst does not work for the following reason:

- rstcheck only checks .rst files but ignores the generated .rep files.

This is a possible fix.

**CAUTION:** I checked if `copyreplace.py` is used somewhere else, but did not find anything. Please confirm this will not break other things.

(I also added it to the makefile which seems useful in my opinion. Therefore, could also be used as `make lint` in the pipeline. However, if there is a reason why you don't want the lint in the makefile let me know)

## This fixes or addresses the following GitHub issues:

- Fixes #350
