### PR TITLE
Add binfmt qemu-user-static image for linux/arm64

### DIFF
--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -496,6 +496,16 @@ packages, or using the `multiarch/qemu-user-static
    Running this container with sudo will modify system configuration files, and
    register binaries on the host.
 
+.. note::
+
+   The "multiarch" image above is only available for amd64, if you are running on
+   arm64 you can use `tonistiigi/binfmt <https://github.com/tonistiigi/binfmt>`__
+   container instead, to the same effect (it is also using qemu-user-static):
+
+.. code:: console
+
+   $ sudo {command} run docker://tonistiigi/binfmt --install all
+
 It is now possible to run containers for other architectures:
 
 .. code:: console


### PR DESCRIPTION
Unfortunately "qemu-user-static" package is broken on Ubuntu 24.04 LTS (in QEMU version 8.2 that is)

## Description of the Pull Request (PR):

Write your description of the PR here. Be sure to include as much background,
and details necessary for the reviewers to understand exactly what this is
fixing or enhancing.

Ironically, the [multiarch](https://hub.docker.com/u/multiarch) images are not... multiarch. (they are also outdated)

https://apptainer.org/docs/user/latest/docker_and_oci.html#cpu-emulation

```
afb@lima-apptainer:~$ sudo apptainer run docker://multiarch/qemu-user-static --reset -p yes
INFO:    Converting OCI blobs to SIF format
INFO:    Starting build...
INFO:    Fetching OCI image...
72.7MiB / 72.7MiB [=========================================================================================================================] 100 % 12.2 MiB/s 0s
2.5MiB / 2.5MiB [===========================================================================================================================] 100 % 12.2 MiB/s 0s
INFO:    Extracting OCI image...
INFO:    Inserting Apptainer configuration...
INFO:    Creating SIF file...
[======================================================================================================================================================] 100 % 0s
FATAL:   While checking container encryption: could not open image /root/.apptainer/cache/oci-tmp/ce8a233e6a43049c175ae5c3738f36decc88206e3e39d498c36032af039ad7d8: the image's architecture (amd64) could not run on the host's (arm64)
```

## This fixes or addresses the following GitHub issues:

- https://github.com/apptainer/apptainer/issues/3482#issuecomment-4415264943


```
$ sudo apptainer run docker://tonistiigi/binfmt --install all
INFO:    Converting OCI blobs to SIF format
INFO:    Starting build...
INFO:    Fetching OCI image...
2.2MiB / 2.2MiB [============================================================================================================================] 100 % 5.7 MiB/s 0s
27.4MiB / 27.4MiB [==========================================================================================================================] 100 % 5.7 MiB/s 0s
INFO:    Extracting OCI image...
INFO:    Inserting Apptainer configuration...
INFO:    Creating SIF file...
[======================================================================================================================================================] 100 % 0s
WARNING: passwd file doesn't exist in container, not updating
WARNING: group file doesn't exist in container, not updating
installing: s390x OK
installing: ppc64le OK
installing: 386 OK
installing: mips64le OK
installing: mips64 OK
installing: riscv64 OK
installing: loong64 OK
installing: arm OK
{
  "supported": [
    "linux/arm64",
    "linux/amd64",
    "linux/amd64/v2",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/loong64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "python3.12",
    "qemu-arm",
    "qemu-i386",
    "qemu-loongarch64",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x",
    "qemu-x86_64"
  ]
}
```
