### PR TITLE
Updates on BIND vs BINDPATH vs MOUNT with nonest behaviors

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -52,10 +52,11 @@ below with their respective functionality.
 
 #. **{ENVPREFIX}_BIND** and **{ENVPREFIX}_BINDPATH**: Comma separated
    string ``source:<dest>`` list of paths to bind between the host and
-   the container, applied in that order.
-   Note that ``{ENVPREFIX}_BIND`` is also automatically set inside a
-   container to list all the paths bound to it, so that by default all
-   the same binds will be applied to nested {command} commands.
+   the container. These are equivalent aliases and are combined together.
+   Note that ``{ENVPREFIX}_BIND`` is automatically set inside a
+   container to list all the paths bound to it (from both variables,
+   ``--bind``, and ``--mount``), so that by default all the same binds
+   will be applied to nested {command} commands.
 
 #. **{ENVPREFIX}_BLKIO_WEIGHT**: Specify a relative weight for block
    device access during contention. Range 10-1000. Default is 0 (disabled).

--- a/appendix.rst
+++ b/appendix.rst
@@ -52,9 +52,10 @@ below with their respective functionality.
 
 #. **{ENVPREFIX}_BIND** and **{ENVPREFIX}_BINDPATH**: Comma separated
    string ``source:<dest>`` list of paths to bind between the host and
-   the container. These are equivalent aliases and are combined together.
-   Note that ``{ENVPREFIX}_BIND`` is automatically set inside a
-   container to list all the paths bound to it (from both variables,
+   the container.  Both are read and the paths from them are combined,
+   in that order.
+   Note that only ``{ENVPREFIX}_BIND`` is automatically set inside a
+   container, listing all the paths bound to it (from both variables,
    ``--bind``, and ``--mount``), so that by default all the same binds
    will be applied to nested {command} commands.
 

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -113,6 +113,7 @@ The {Project} action commands (``run``, ``exec``, ``shell``, and
 ``instance start``) will accept the ``--bind/-B`` command-line option to
 specify bind paths, and will also honor the ``${ENVPREFIX}_BIND`` and
 ``${ENVPREFIX}_BINDPATH`` environment variables (in that order).
+
 The argument for this
 option is a comma-delimited string of bind path specifications in the
 format ``src[:dest[:opts]]``, where ``src`` and ``dest`` are paths
@@ -161,20 +162,27 @@ this would be:
 
    $ {command} shell my_container.sif
 
-Using the environment variable ``${ENVPREFIX}_BINDPATH``, you can bind paths
-even when you are running your container as an executable file with a
-runscript. If you bind many directories into your {Project}
-containers and they don't change, you could even benefit by setting this
-variable in your ``.bashrc`` file.
+Using the environment variables, you can bind paths even when you are
+running your container as an executable file with a runscript. If you
+bind many directories into your {Project} containers and they don't
+change, you could even benefit by setting one of these variables in your
+``.bashrc`` file.
 
 .. note::
 
    Inside {aProject} container all the paths that were bound in are set
    in the ``${ENVPREFIX}_BIND`` variable.  That means they will be
    automatically bound in again by default if another {command} command is
-   run nested inside the first container.  You can change that variable
-   if you choose before that point, but if you want to avoid interfering
-   with nested containers it's better to use ``${ENVPREFIX}_BINDPATH``.
+   run nested inside the first container.
+
+   Unlike in Singularity, ``${ENVPREFIX}_BIND`` and
+   ``${ENVPREFIX}_BINDPATH`` are equivalent aliases in {Project} —
+   both set up the same bind mounts and both are propagated to nested
+   containers.  To bind a path without propagating it to nested
+   containers, use ``--mount`` with the ``nonested`` option (see
+   :ref:`--mount Examples <sec:mount_examples>` below).
+
+.. _sec:mount_examples:
 
 ``--mount`` Examples
 ====================
@@ -240,6 +248,19 @@ wrapping each field in double quotes if necessary characters.
 Mount specifications are also read from then environment variable
 ``${ENVPREFIX}_MOUNT``. Multiple bind mounts set via this environment
 variable should be separated by newlines (``\n``).
+
+To prevent a ``--mount`` bind from being propagated to nested containers
+via ``${ENVPREFIX}_BIND``, add the ``nonested`` flag:
+
+.. code:: console
+
+   $ {command} exec \
+       --mount type=bind,src=/data,dst=/mnt,nonested \
+       my_container.sif env | grep {ENVPREFIX}_BIND
+
+The mount will still be applied inside the container, but its
+destination will not appear in the ``${ENVPREFIX}_BIND`` variable,
+so nested {command} commands will not inherit it.
 
 Using ``--bind`` or ``--mount`` with the ``--writable`` flag
 ============================================================

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -175,11 +175,16 @@ change, you could even benefit by setting one of these variables in your
    automatically bound in again by default if another {command} command is
    run nested inside the first container.
 
-   Unlike in Singularity, ``${ENVPREFIX}_BIND`` and
-   ``${ENVPREFIX}_BINDPATH`` are equivalent aliases in {Project} —
-   both set up the same bind mounts and both are propagated to nested
-   containers.  To bind a path without propagating it to nested
-   containers, use ``--mount`` with the ``nonested`` option (see
+   Only ``${ENVPREFIX}_BIND`` is set inside the container, so
+   ``${ENVPREFIX}_BINDPATH`` is the easier of the two to use there.  Both
+   variables are read and the paths from them are combined, so adding to
+   ``${ENVPREFIX}_BINDPATH`` leaves the inherited list alone.  Edit
+   ``${ENVPREFIX}_BIND`` when you want to change what a nested {command}
+   command inherits.  Outside of a container the two are interchangeable.
+
+   Paths bound in through either variable are still passed on to nested
+   containers.  To bind a path without passing it on, use ``--mount``
+   with the ``nonested`` option (see
    :ref:`--mount Examples <sec:mount_examples>` below).
 
 .. _sec:mount_examples:


### PR DESCRIPTION
- stating that _BIND and _BINDPATH are just aliases when *setting* the env variables, but have a different behavior when you're *inside*
- add new recommendation (--mount with option nonest) to avoid propagating bind configurations to the nested containers
- docs for nonest option for --mount with an example