### PR TITLE
Add information about other docker build sources

### DIFF
--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -25,7 +25,10 @@ as output.
 The type of target given determines the method that ``build`` will use
 to create the container. It can be one of the following:
 
--  URI beginning with **docker://** to build from Docker Hub
+-  URI beginning with **docker://** to build from Docker Hub and other OCI Image registries
+-  URI beginning with **docker-daemon:** to build from a running Docker daemon
+-  URI beginning with **docker-archive:** to build from a saved Docker image
+-  URI beginning with **dockerfile:** to build from a Dockerfile directory
 -  URI beginning with **oras://** to build from an OCI registry that supports OCI Artifacts
 -  URI beginning with **ipfs://** to build from an IPFS cluster that supports CID images
 -  URI beginning with **library://** to build from the Container Library
@@ -66,6 +69,33 @@ them into {Project} containers.
 .. code:: console
 
    $ {command} build alpine.sif docker://alpine
+
+.. note::
+
+   You can use other registries, not only Docker Hub (also known as ``docker.io``)
+
+   See the :ref:`OCI Image Registries <registry>` section in this guide, e.g.
+   ``quay.io`` or ``ghcr.io``.
+
+*************************************************
+Reusing existing containers from Docker or Podman
+*************************************************
+
+You can use containers that already exist in a local daemon or in a
+local file.
+
+.. code:: console
+
+   $ {command} build alpine.sif docker-daemon:alpine:latest
+
+See :ref:`containers-cached-by-the-docker-daemon` for more details.
+
+.. code:: console
+
+   $ docker image save alpine --output alpine.tar
+   $ {command} build alpine.sif docker-archive:alpine.tar
+
+See :ref:`containers-in-docker-archive-files` for more details.
 
 **************************
 Specifying an architecture

--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -650,6 +650,8 @@ found inside a running Docker daemon, or saved as an archive.
 {Project} can build from these locations by using specialized
 bootstrap agents.
 
+.. _containers-cached-by-the-docker-daemon:
+
 Containers Cached by the Docker Daemon
 --------------------------------------
 
@@ -727,6 +729,8 @@ use ``Bootstrap: docker-daemon``, and a ``From: <REPOSITORY>:TAG`` line:
 
 To use the "created" date of the input image also for the output image, you
 can use the ``--reproducible`` flag or the ``APPTAINER_REPRODUCIBLE`` env var.
+
+.. _containers-in-docker-archive-files:
 
 Containers in Docker Archive Files
 ----------------------------------


### PR DESCRIPTION
Add docker-daemon and docker-archive sources, and mention that there are other image registries beyond just docker.io

Note that the Docker support also works for Podman, assuming that the podman.socket has been activated for a podman.sock.

## Description of the Pull Request (PR):

The `docker-daemon` and `docker-archive` formats were missing.

Cross-reference them in build, to the section about [Docker and OCI](https://apptainer.org/docs/user/main/docker_and_oci.html)

## This fixes or addresses the following GitHub issues:

- https://github.com/apptainer/apptainer/issues/3682
